### PR TITLE
Add Task Registry for registering and grouping tasks

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -26,6 +26,9 @@ type Cache struct {
 	opts []shell.RunOption
 }
 
+// Ignore ignores the cache (useful for conditionally bypassing the cache).
+func (c *Cache) Ignore() { c.allDirty = true }
+
 func New(opts ...shell.RunOption) *Cache {
 	return &Cache{
 		ranOnce: make(map[*taskrunner.Task]bool),

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -108,6 +108,7 @@ func (c *Cache) maybeRun(task *taskrunner.Task) func(context.Context, shell.Shel
 			logger := taskrunner.LoggerFromContext(ctx)
 			if logger != nil {
 				fmt.Fprintln(logger.Stdout, "no changes (cache)")
+				return nil
 			}
 		}
 		return task.Run(ctx, shellRun)

--- a/cache/git.go
+++ b/cache/git.go
@@ -46,6 +46,9 @@ func (g gitClient) uncomittedFiles(ctx context.Context) (newFiles []string, modi
 	}
 
 	for _, statusLine := range splitStdout(buffer) {
+		if len(strings.TrimSpace(statusLine)) < 4 {
+			continue
+		}
 		if strings.HasPrefix(statusLine, "??") {
 			newFiles = append(newFiles, statusLine[3:])
 		} else {

--- a/clireporter/cli.go
+++ b/clireporter/cli.go
@@ -75,7 +75,11 @@ func option(logger *logger) func(*taskrunner.Runtime) {
 				case *taskrunner.TaskStartedEvent:
 					logger.Write(task, "Started")
 				case *taskrunner.TaskCompletedEvent:
-					logger.Writef(task, "Completed (%0.2fs)", float64(event.Duration)/float64(time.Second))
+					if event.Duration == 0 {
+						logger.Writef(task, "Completed")
+					} else {
+						logger.Writef(task, "Completed (%0.2fs)", float64(event.Duration)/float64(time.Second))
+					}
 				case *taskrunner.TaskFailedEvent:
 					logger.Writef(task, "Failed\n%v", event.Error)
 				case *taskrunner.TaskDiagnosticEvent:

--- a/executor.go
+++ b/executor.go
@@ -265,9 +265,11 @@ func (e *Executor) runPass() {
 					})
 
 					started := time.Now()
+					var duration time.Duration
 
 					if task.Run != nil {
 						err = task.Run(ctx, e.ShellRun)
+						duration = time.Since(started)
 					}
 
 					if ctx.Err() == context.Canceled {
@@ -283,7 +285,7 @@ func (e *Executor) runPass() {
 					} else {
 						e.publishEvent(&TaskCompletedEvent{
 							simpleEvent: execution.simpleEvent(),
-							Duration:    time.Since(started),
+							Duration:    duration,
 						})
 						execution.state = taskExecutionState_done
 					}

--- a/executor.go
+++ b/executor.go
@@ -266,7 +266,9 @@ func (e *Executor) runPass() {
 
 					started := time.Now()
 
-					err = task.Run(ctx, e.ShellRun)
+					if task.Run != nil {
+						err = task.Run(ctx, e.ShellRun)
+					}
 
 					if ctx.Err() == context.Canceled {
 						e.publishEvent(&TaskStoppedEvent{

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,65 @@
+package taskrunner
+
+import (
+	"fmt"
+	"sort"
+)
+
+// DefaultRegistry is where tasks are registered to through the package-level functions Add, Group
+// and Tasks.
+var DefaultRegistry = NewRegistry()
+
+// NewRegistry creates a new task registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		definitions: make(map[string]*Task),
+	}
+}
+
+// Registry is an object that keeps track of task definitions.
+type Registry struct {
+	definitions map[string]*Task
+}
+
+type TaskOption func(*Task) *Task
+
+// Add registers a task, failing if the name has already been taken.
+func (r *Registry) Add(t *Task, opts ...TaskOption) *Task {
+	for _, opt := range opts {
+		t = opt(t)
+	}
+	if _, ok := r.definitions[t.Name]; ok {
+		panic(fmt.Sprintf("Duplicate task registered: %s", t.Name))
+	}
+	r.definitions[t.Name] = t
+	return t
+}
+
+// Group creates a pseudo-task that groups other tasks underneath it. It explicitly doesn't expose
+// the pseudo-task because groups are not allowed to be dependencies.
+func (r *Registry) Group(name string, tasks ...*Task) {
+	r.Add(&Task{
+		Name:         name,
+		Dependencies: tasks,
+	})
+}
+
+// Tasks returns all registered tasks in alphabetical order.
+func (r *Registry) Tasks() (list []*Task) {
+	for _, t := range r.definitions {
+		list = append(list, t)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
+	return list
+}
+
+// Add registers a task, failing if the name has already been taken.
+var Add = DefaultRegistry.Add
+
+// Group creates a pseudo-task that groups other tasks underneath it.
+var Group = DefaultRegistry.Group
+
+// Tasks returns all registered tasks in alphabetical order.
+var Tasks = DefaultRegistry.Tasks

--- a/runner.go
+++ b/runner.go
@@ -34,6 +34,7 @@ type Runtime struct {
 	subscriptions   []func(events <-chan ExecutorEvent) error
 	onStartHooks    []func(ctx context.Context, executor *Executor) error
 	onStopHooks     []func(ctx context.Context, executor *Executor) error
+	registry        *Registry
 	executorOptions []ExecutorOption
 }
 
@@ -61,8 +62,8 @@ func ExecutorOptions(opts ...ExecutorOption) RunOption {
 	}
 }
 
-func Run(tasks []*Task, options ...RunOption) {
-	runtime := &Runtime{}
+func Run(options ...RunOption) {
+	runtime := &Runtime{registry: DefaultRegistry}
 	for _, option := range options {
 		option(runtime)
 	}
@@ -82,6 +83,8 @@ func Run(tasks []*Task, options ...RunOption) {
 	if err != nil {
 		log.Fatalf("config error: unable to read config:\n%v\n", err)
 	}
+
+	tasks := runtime.registry.Tasks()
 
 	if listTasks {
 		outputString := "Run specified tasks with `taskrunner taskname1 taskname2`\nTasks available:"

--- a/runner.go
+++ b/runner.go
@@ -12,21 +12,10 @@ import (
 )
 
 var (
-	flags          = flag.NewFlagSet("taskrunner", 0)
 	configFile     string
 	nonInteractive bool
 	listTasks      bool
 )
-
-func init() {
-	flags.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: taskrunner [task...]\n")
-		flags.PrintDefaults()
-	}
-	flags.StringVar(&configFile, "config", "", "Configuration file to use")
-	flags.BoolVar(&nonInteractive, "non-interactive", false, "Non-interactive mode")
-	flags.BoolVar(&listTasks, "list", false, "List all tasks")
-}
 
 // Runtime represents the external interface of an Executor's runtime. It is how taskrunner
 // extensions can register themselves to taskrunner's lifecycle.
@@ -34,8 +23,27 @@ type Runtime struct {
 	subscriptions   []func(events <-chan ExecutorEvent) error
 	onStartHooks    []func(ctx context.Context, executor *Executor) error
 	onStopHooks     []func(ctx context.Context, executor *Executor) error
-	registry        *Registry
 	executorOptions []ExecutorOption
+
+	registry *Registry
+	flags    *flag.FlagSet
+}
+
+func newRuntime() *Runtime {
+	r := &Runtime{
+		registry: DefaultRegistry,
+		flags:    flag.NewFlagSet("taskrunner", 0),
+	}
+
+	r.flags.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: taskrunner [task...]\n")
+		r.flags.PrintDefaults()
+	}
+	r.flags.StringVar(&configFile, "config", "", "Configuration file to use")
+	r.flags.BoolVar(&nonInteractive, "non-interactive", false, "Non-interactive mode")
+	r.flags.BoolVar(&listTasks, "list", false, "List all tasks")
+
+	return r
 }
 
 // OnStart is run after taskrunner has built up its task execution list.
@@ -54,6 +62,9 @@ func (r *Runtime) OnStop(f func(context.Context, *Executor) error) {
 	r.onStopHooks = append(r.onStopHooks, f)
 }
 
+// WithFlag allows for external registration of flags.
+func (r *Runtime) WithFlag(f func(flags *flag.FlagSet)) { f(r.flags) }
+
 type RunOption func(options *Runtime)
 
 func ExecutorOptions(opts ...ExecutorOption) RunOption {
@@ -63,12 +74,12 @@ func ExecutorOptions(opts ...ExecutorOption) RunOption {
 }
 
 func Run(options ...RunOption) {
-	runtime := &Runtime{registry: DefaultRegistry}
+	runtime := newRuntime()
 	for _, option := range options {
 		option(runtime)
 	}
 
-	if err := flags.Parse(os.Args[1:]); err != nil {
+	if err := runtime.flags.Parse(os.Args[1:]); err != nil {
 		return
 	}
 
@@ -100,9 +111,9 @@ func Run(options ...RunOption) {
 
 	desiredTasks := config.DesiredTasks
 	config.Watch = !nonInteractive
-	if len(flags.Args()) > 0 {
+	if len(runtime.flags.Args()) > 0 {
 		config.Watch = false
-		desiredTasks = flags.Args()
+		desiredTasks = runtime.flags.Args()
 	}
 
 	if len(tasks) == 0 {


### PR DESCRIPTION
Tasks will now be able to be registered like this:

```go
var genGQL = taskrunner.Add(&taskrunner.Task{
  // ...
})

taskrunner.Group(
  "gen",
  genGQL, // ...
)
```

and `Run` will just take run options:

```go
taskrunner.Run(...opts)
```