### PR TITLE
taskrunner: propagate well-known undefined task name error

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -2,6 +2,7 @@ package taskrunner
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -43,6 +44,8 @@ type Executor struct {
 	// eventsCh keeps track of subscribers to events for this executor.
 	eventsChs []chan ExecutorEvent
 }
+
+var errUndefinedTaskName = errors.New("undefined task name")
 
 type ExecutorOption func(*Executor)
 
@@ -175,7 +178,7 @@ func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime
 	for _, taskName := range taskNames {
 		task := e.taskRegistry[taskName]
 		if task == nil {
-			return oops.Errorf("task %s is not defined", taskName)
+			return oops.Wrapf(errUndefinedTaskName, "task %s is not defined", taskName)
 		}
 		taskSet.add(ctx, task)
 	}

--- a/runner.go
+++ b/runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/samsarahq/go/oops"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -138,10 +139,12 @@ func Run(options ...RunOption) {
 		err := executor.Run(ctx, desiredTasks, runtime)
 
 		// We only care about propagating errors up to the errgroup
-		// if we were not in watch mode.
-		if !config.Watch {
+		// if it's a well-known executor error, or the underlying task failed AND
+		// we're not in watch mode.
+		if oops.Cause(err) == errUndefinedTaskName || !config.Watch {
 			return err
 		}
+
 		return nil
 	})
 


### PR DESCRIPTION
This PR fixes an issue where errors for unknown tasks are not propagated in watch mode.

example output:
```
$taskrunner
2019/03/05 13:08:08 Using config /project/user.taskrunner.json
2019/03/05 13:08:08 Desired tasks: whatever
2019/03/05 13:08:08 Watch mode: true
2019/03/05 13:08:08 run error:
undefined task name

github.com/samsarahq/taskrunner.(*Executor).Run: task whatever is not defined
```