### PR TITLE
Add a Description field for more detailed documentation of tasks

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -17,6 +17,7 @@ var (
 	nonInteractive bool
 	listTasks      bool
 	watch          bool
+	describeTasks  bool
 )
 
 // Runtime represents the external interface of an Executor's runtime. It is how taskrunner
@@ -45,6 +46,7 @@ func newRuntime() *Runtime {
 	r.flags.BoolVar(&nonInteractive, "non-interactive", false, "Non-interactive mode (only applies when running the default set of tasks)")
 	r.flags.BoolVar(&listTasks, "list", false, "List all tasks")
 	r.flags.BoolVar(&watch, "watch", false, "Run in watch mode (only applies when passing custom tasks)")
+	r.flags.BoolVar(&describeTasks, "describe", false, "Describe all tasks")
 
 	return r
 }
@@ -104,6 +106,15 @@ func Run(options ...RunOption) {
 		outputString := "Run specified tasks with `taskrunner taskname1 taskname2`\nTasks available:"
 		for _, task := range tasks {
 			outputString = outputString + "\n\t" + task.Name
+		}
+		fmt.Println(outputString)
+		return
+	}
+
+	if describeTasks {
+		var outputString string
+		for _, task := range tasks {
+			outputString = fmt.Sprintf("%s\n\t%s\t %s", outputString, task.Name, task.Description)
 		}
 		fmt.Println(outputString)
 		return

--- a/task.go
+++ b/task.go
@@ -8,6 +8,10 @@ import (
 
 type Task struct {
 	Name string
+
+	// A one or two sentence description of what the task does
+	Description string
+
 	// XXX: Pass files in so that task can decide to do less work, i.e. if
 	// you change a go file we can run go fmt on just that file.
 


### PR DESCRIPTION
example output: 

```
$ taskrunner -describe
...
    mytask
    mytask/build	 Generates client bundle. Compiles typescript.
```

I tested this by adding a `Description` field to a task called `mytask/build`

I added a -describe option instead of modifying -list because I wanted to maintain fzf (fuzzy find) compatibility. I tried running taskrunner commands with fzf using -describe instead of -list. No matter what punctuation I wrapped the Description with, taskrunner always tried to run every word in the description as a task. I tried # and quotes and semi-colons.