### PR TITLE
watcher: fix event names for linux

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -129,7 +129,7 @@ func (w *INotifyWatcher) Run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	// XXX: hack: ignore node_modules because inotify has a 8192 limit by default.
-	cmd := exec.CommandContext(ctx, "inotifywait", "-q", "-m", "@./node_modules", "@./mobile/Troy/node_modules", "@./integration/canary/node_modules", "@./mobile/SamsaraDriver/node_modules", "-r", "-e", "modify", "-e", "create", "-e", "delete", "-e", "move", w.directory)
+	cmd := exec.CommandContext(ctx, "inotifywait", "-q", "-m", "--exclude", "(node_modules|npm-packages-offline-cache)", "-r", "-e", "modify", "-e", "create", "-e", "delete", "-e", "move", w.directory)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -151,8 +151,8 @@ func (w *INotifyWatcher) Run(ctx context.Context) error {
 				"ATTRIB":    NumericEventFlagAttributeModified,
 				"CREATE":    NumericEventFlagCreated,
 				"DELETE":    NumericEventFlagRemoved,
-				"MOVE_TO":   NumericEventFlagMovedTo,
-				"MOVE_FROM": NumericEventFlagMovedFrom,
+				"MOVED_TO":   NumericEventFlagMovedTo,
+				"MOVED_FROM": NumericEventFlagMovedFrom,
 				"MODIFY":    NumericEventFlagUpdated,
 			}[line[1]]
 


### PR DESCRIPTION
There was a typo in the eventFlag map, the actual events are called `MOVED_TO` and `MOVED_FROM`. This was causing taskrunner to silently kill the watcher goroutine when either of these events came through

I also changed the ignore hack to be generalized to all of the `node_modules` folders; `--exclude` does a regex match

Considerations:
* we might want to also ignore `copied-ts` folders for driver app and Troy
* we might want to also ignore `.git/index.lock`