### PR TITLE
Add shorthand flag -desc for -describe flag

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -47,6 +47,7 @@ func newRuntime() *Runtime {
 	r.flags.BoolVar(&listTasks, "list", false, "List all tasks")
 	r.flags.BoolVar(&watch, "watch", false, "Run in watch mode (only applies when passing custom tasks)")
 	r.flags.BoolVar(&describeTasks, "describe", false, "Describe all tasks")
+	r.flags.BoolVar(&describeTasks, "desc", false, "Shorthand for -describe")
 
 	return r
 }


### PR DESCRIPTION
I love `-describe` flag, but since it is not auto completed, I find it too much to type. A `-desc` shorthand alias is also 5 chars, just like `-list` command.