### PR TITLE
go config: Resolve symbolic links for fswatch

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,6 +98,11 @@ func (config *Config) WorkingDir() string {
 		log.Fatalf("config error: unable to find config file (%s):\n%v\n", config.configPath, err)
 	}
 
+	configPath, err = filepath.EvalSymlinks(configPath)
+	if err != nil {
+		log.Fatalf("config error: unable to remove symbolic links for filepath (%s):\n%v\n", configPath, err)
+	}
+
 	return filepath.Join(filepath.Dir(configPath), config.Path)
 }
 


### PR DESCRIPTION
Summary: If your main directory resolves from a symbolic link,
then you won't get taskrunner invalidation from fswatch (it requires
non-symbolic links).  This commit changes the "WorkingDir" to resolve
symbolic links to get a "true" absolute directory.

We found this after scratching our heads a while trying to figure out
why we couldn't get invalidations to work.

Test Plan: cd'ed to a symbolic link firmware directory, tested that
taskrunner invalidations didn't work before this change, and that they
did work after the change.