### PR TITLE
Pass cl args to tasks

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -108,8 +108,8 @@ func (c *Cache) isValid(task *taskrunner.Task) bool {
 	return true
 }
 
-func (c *Cache) maybeRun(task *taskrunner.Task) func(context.Context, shell.ShellRun) error {
-	return func(ctx context.Context, shellRun shell.ShellRun) error {
+func (c *Cache) maybeRun(task *taskrunner.Task) func(context.Context, shell.ShellRun, *string) error {
+	return func(ctx context.Context, shellRun shell.ShellRun, flagString *string) error {
 		if c.isFirstRun(task) && c.isValid(task) {
 			// report that the task wasn't run
 			logger := taskrunner.LoggerFromContext(ctx)
@@ -118,7 +118,7 @@ func (c *Cache) maybeRun(task *taskrunner.Task) func(context.Context, shell.Shel
 				return nil
 			}
 		}
-		return task.Run(ctx, shellRun)
+		return task.Run(ctx, shellRun, flagString)
 	}
 }
 

--- a/executor.go
+++ b/executor.go
@@ -161,7 +161,7 @@ func (e *Executor) Invalidate(task *Task, event InvalidationEvent) {
 	e.invalidationCh <- struct{}{}
 }
 
-func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime) error {
+func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime, flagString *string) error {
 	e.ctx = ctx
 	defer func() {
 		for _, ch := range e.eventsChs {
@@ -180,6 +180,7 @@ func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime
 		if task == nil {
 			return oops.Wrapf(errUndefinedTaskName, "task %s is not defined", taskName)
 		}
+		task.Flags = flagString
 		taskSet.add(ctx, task)
 	}
 
@@ -275,7 +276,7 @@ func (e *Executor) runPass() {
 					var duration time.Duration
 
 					if task.Run != nil {
-						err = task.Run(ctx, e.ShellRun)
+						err = task.Run(ctx, e.ShellRun, task.Flags)
 						duration = time.Since(started)
 					}
 

--- a/executor_test.go
+++ b/executor_test.go
@@ -34,7 +34,7 @@ func TestExecutorSimple(t *testing.T) {
 
 	taskA := &taskrunner.Task{
 		Name: "A",
-		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+		Run: func(ctx context.Context, shellRun shell.ShellRun, flags *string) error {
 			mockA.Fn()
 			return nil
 		},
@@ -42,7 +42,7 @@ func TestExecutorSimple(t *testing.T) {
 
 	taskB := &taskrunner.Task{
 		Name: "B",
-		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+		Run: func(ctx context.Context, shellRun shell.ShellRun, flags *string) error {
 			mockB.Fn()
 			return nil
 		},
@@ -61,7 +61,7 @@ func TestExecutorSimple(t *testing.T) {
 		{
 			"single task",
 			func(t *testing.T) {
-				executor.Run(ctx, []string{"A"}, &taskrunner.Runtime{})
+				executor.Run(ctx, []string{"A"}, &taskrunner.Runtime{}, nil)
 				mockA.ExpectCalls(t, 1)
 				mockB.ExpectCalls(t, 0)
 			},
@@ -70,7 +70,7 @@ func TestExecutorSimple(t *testing.T) {
 			"dependent task",
 			func(t *testing.T) {
 				ctx = context.Background()
-				executor.Run(ctx, []string{"B"}, &taskrunner.Runtime{})
+				executor.Run(ctx, []string{"B"}, &taskrunner.Runtime{}, nil)
 
 				mockA.ExpectCalls(t, 1)
 				mockB.ExpectCalls(t, 1)
@@ -115,7 +115,7 @@ func TestExecutorInvalidations(t *testing.T) {
 
 	taskA := &taskrunner.Task{
 		Name: "A",
-		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+		Run: func(ctx context.Context, shellRun shell.ShellRun, flags *string) error {
 			mockA.Fn()
 			return nil
 		},
@@ -123,7 +123,7 @@ func TestExecutorInvalidations(t *testing.T) {
 
 	taskB := &taskrunner.Task{
 		Name: "B",
-		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+		Run: func(ctx context.Context, shellRun shell.ShellRun, flags *string) error {
 			mockB.Fn()
 			return nil
 		},
@@ -159,7 +159,7 @@ func TestExecutorInvalidations(t *testing.T) {
 					cancel()
 				}()
 
-				executor.Run(ctx, []string{"B"}, &taskrunner.Runtime{})
+				executor.Run(ctx, []string{"B"}, &taskrunner.Runtime{}, nil)
 			},
 		},
 		{
@@ -184,7 +184,7 @@ func TestExecutorInvalidations(t *testing.T) {
 					cancel()
 				}()
 
-				executor.Run(ctx, []string{"B"}, &taskrunner.Runtime{})
+				executor.Run(ctx, []string{"B"}, &taskrunner.Runtime{}, nil)
 			},
 		},
 	} {

--- a/goextensions/builder.go
+++ b/goextensions/builder.go
@@ -203,7 +203,7 @@ func (builder *GoBuilder) WrapWithGoBuild(pkg string) taskrunner.TaskOption {
 		newTask := *task
 
 		buildBinder := newBuildBinder(pkg)
-		newTask.Run = func(ctx context.Context, shellRun shell.ShellRun) error {
+		newTask.Run = func(ctx context.Context, shellRun shell.ShellRun, flags *string) error {
 			if err := builder.Build(ctx, shellRun, pkg); err != nil {
 				return err
 			}
@@ -213,7 +213,7 @@ func (builder *GoBuilder) WrapWithGoBuild(pkg string) taskrunner.TaskOption {
 			}
 
 			if task.Run != nil {
-				return task.Run(ctx, shellRun)
+				return task.Run(ctx, shellRun, flags)
 			}
 
 			return nil

--- a/task.go
+++ b/task.go
@@ -9,7 +9,8 @@ import (
 type Task struct {
 	Name string
 
-	// A one or two sentence description of what the task does
+	// A one or two sentence description of what the task does. If this task
+	// accepts command line args, include information about them here.
 	Description string
 
 	// XXX: Pass files in so that task can decide to do less work, i.e. if
@@ -17,7 +18,7 @@ type Task struct {
 
 	// Run is called when the task should be run. The function should gracefully
 	// handle context cancelation.
-	Run func(ctx context.Context, shellRun shell.ShellRun) error
+	Run func(ctx context.Context, shellRun shell.ShellRun, flagString *string) error
 
 	ShouldInvalidate func(event InvalidationEvent) bool
 
@@ -35,4 +36,8 @@ type Task struct {
 
 	// Ignore is a set of globs subtracted from Sources.
 	Ignore []string
+
+	// Flags is a string that represents command line args recognized by this task.
+	// Flags are passed in from Taskrunner exactly as entered by a user.
+	Flags *string
 }


### PR DESCRIPTION
Adds a `withFlags` flag to taskrunner that allows an end user to provide a string of command line args that will be passed down to the task. Example usage looks like:

`taskrunner --withFlags="--dryrun" taskname` 

It is left up to individual tasks to implement all arg behavior, and describe that behavior in the task.Description. 

Notes:
- At the moment, this only works when taskrunner is used to invoke a single task. This is to prevent unintended side effects/argument collision among invoked tasks.
- This PR updates the type for task.Run, so existing tasks would need to be updated. 