### PR TITLE
clireporter: buffer output by line

### DIFF
--- a/clireporter/linebufferedwriter.go
+++ b/clireporter/linebufferedwriter.go
@@ -1,0 +1,21 @@
+package clireporter
+
+import "bufio"
+
+type LineBufferedWriter struct {
+	*bufio.Writer
+}
+
+func (w *LineBufferedWriter) Write(p []byte) (n int, err error) {
+	for _, c := range p {
+		if err = w.WriteByte(c); err != nil {
+			break
+		}
+
+		n++
+		if c == '\n' {
+			w.Flush()
+		}
+	}
+	return n, err
+}


### PR DESCRIPTION
Some tools, like jest, output non-buffered text, which causes
taskrunner to split the output across multiple lines non-deterministically.

This change effectively does the same thing as https://github.com/samsara-dev/backend/pull/46555, except it does it internal to taskrunner rather than as part of the task itself.

Only one of these 2 PRs needs to merge for the output to be fixed.

I don't have a strong preference for which one we pick; the other PR is unable to have side effects in other tasks though