### PR TITLE
executor: check context cancellation before invalidation

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -130,6 +130,9 @@ func (e *Executor) runInvalidationLoop() {
 			case <-e.invalidationCh:
 				timer.Reset(time.Second)
 
+			case <-e.ctx.Done():
+				return
+
 			case <-timer.C:
 				e.evaluateInvalidationPlan()
 				go e.runPass()


### PR DESCRIPTION
We noticed an issue with short-lived KeepAlive tasks where the invalidation
plan would be attempted after shutdown had already started. To prevent that from
panicking during shutdown (we'd try to publish events on a closed event channel),
we check context cancellation here before running any invalidation.

In general, the concurrency story in the executor feels pretty fragile - we may consider
re-examining this code in more detail later. I want to ship this change as a stop-gap
in the meantime.