### PR TITLE
executor: add canceled state

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -277,6 +277,10 @@ func (e *Executor) provideEventLogger(t *Task) *Logger {
 
 // runPass kicks off tasks that are in an executable state.
 func (e *Executor) runPass() {
+	if e.ctx.Err() != nil {
+		return
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 

--- a/executor.go
+++ b/executor.go
@@ -318,11 +318,11 @@ func (e *Executor) runPass() {
 							Error:       err,
 						})
 					} else {
+						execution.state = taskExecutionState_done
 						e.publishEvent(&TaskCompletedEvent{
 							simpleEvent: execution.simpleEvent(),
 							Duration:    duration,
 						})
-						execution.state = taskExecutionState_done
 					}
 
 					// It's important that we flush the error/done states before

--- a/executor.go
+++ b/executor.go
@@ -308,6 +308,7 @@ func (e *Executor) runPass() {
 					}
 
 					if ctx.Err() == context.Canceled {
+						execution.state = taskExecutionState_canceled
 						e.publishEvent(&TaskStoppedEvent{
 							simpleEvent: execution.simpleEvent(),
 						})

--- a/task_execution.go
+++ b/task_execution.go
@@ -9,9 +9,15 @@ import (
 type taskExecutionState int
 
 const (
+	// taskExecutionState_invalid tasks are not running and are queued to be started
+	// on the next invalidation plan.
 	taskExecutionState_invalid = iota
+	// taskExecutionState_running tasks are currently executing. They may transition to
+	// error on failure or done on succesful completion.
 	taskExecutionState_running
+	// taskExecutionState_error tasks were running and failed. They may transition to invalid.
 	taskExecutionState_error
+	// taskExecutionState_done tasks were running and completed without errors. They may transition to invalid.
 	taskExecutionState_done
 )
 

--- a/task_execution.go
+++ b/task_execution.go
@@ -13,12 +13,15 @@ const (
 	// on the next invalidation plan.
 	taskExecutionState_invalid = iota
 	// taskExecutionState_running tasks are currently executing. They may transition to
-	// error on failure or done on succesful completion.
+	// error on failure or done on succesful completion. Tasks may also be canceled.
 	taskExecutionState_running
 	// taskExecutionState_error tasks were running and failed. They may transition to invalid.
 	taskExecutionState_error
 	// taskExecutionState_done tasks were running and completed without errors. They may transition to invalid.
 	taskExecutionState_done
+	// taskExecutionState_canceled tasks were running and were stopped by the
+	// user. Tasks cannot leave canceled state.
+	taskExecutionState_canceled
 )
 
 // taskExecution is a node in the Executor's DAG. It holds the state
@@ -64,7 +67,7 @@ func (e *taskExecution) ShouldExecute() bool {
 // invalidate stops the task if running, resets the execution
 // state for the task, then invalidates all dependents.
 func (e *taskExecution) invalidate(executionCtx context.Context) {
-	if e.state == taskExecutionState_invalid {
+	if e.state == taskExecutionState_invalid || e.state == taskExecutionState_canceled {
 		return
 	}
 

--- a/task_handler.go
+++ b/task_handler.go
@@ -25,17 +25,19 @@ func (h *TaskHandler) Invalidate(reason InvalidationEvent) {
 type TaskHandlerExecutionState string
 
 const (
-	TaskHandlerExecutionState_Invalid TaskHandlerExecutionState = "invalid"
-	TaskHandlerExecutionState_Running                           = "running"
-	TaskHandlerExecutionState_Error                             = "error"
-	TaskHandlerExecutionState_Done                              = "done"
+	TaskHandlerExecutionState_Invalid  TaskHandlerExecutionState = "invalid"
+	TaskHandlerExecutionState_Running                            = "running"
+	TaskHandlerExecutionState_Error                              = "error"
+	TaskHandlerExecutionState_Done                               = "done"
+	TaskHandlerExecutionState_Canceled                           = "canceled"
 )
 
 var TaskHandlerExecutionStateMap = map[taskExecutionState]TaskHandlerExecutionState{
-	taskExecutionState_invalid: TaskHandlerExecutionState_Invalid,
-	taskExecutionState_running: TaskHandlerExecutionState_Running,
-	taskExecutionState_error:   TaskHandlerExecutionState_Error,
-	taskExecutionState_done:    TaskHandlerExecutionState_Done,
+	taskExecutionState_invalid:  TaskHandlerExecutionState_Invalid,
+	taskExecutionState_running:  TaskHandlerExecutionState_Running,
+	taskExecutionState_error:    TaskHandlerExecutionState_Error,
+	taskExecutionState_done:     TaskHandlerExecutionState_Done,
+	taskExecutionState_canceled: TaskHandlerExecutionState_Canceled,
 }
 
 func (h *TaskHandler) State() TaskHandlerExecutionState {


### PR DESCRIPTION
Canceled is different from done because canceled did not succeed and should not try to kick off further tasks. Previously, canceled tasks would get stuck in running state even though they stopped.