### PR TITLE
shell: add support for setting working directory

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -44,6 +44,13 @@ func Env(vars map[string]string) RunOption {
 	}
 }
 
+// Dir sets the working directory for the command.
+func Dir(dir string) RunOption {
+	return func(r *interp.Runner) {
+		r.Dir = dir
+	}
+}
+
 // Run executes a shell command.
 func Run(ctx context.Context, command string, opts ...RunOption) error {
 	p, err := syntax.NewParser().Parse(strings.NewReader(command), "")


### PR DESCRIPTION
This PR adds the functionality for Taskrunner to run a command from a different directory.

It may come in handy when writing tasks that are not able to be run from the default directory.