### PR TITLE
builder: use runtime pkg to resolve GOROOT

### DIFF
--- a/goextensions/builder.go
+++ b/goextensions/builder.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -27,7 +28,7 @@ func isStdLib(pkg string) bool {
 		return *stdlibLookup[pkg]
 	}
 
-	_, err := os.Stat(filepath.Join(os.Getenv("GOROOT"), "src", pkg))
+	_, err := os.Stat(filepath.Join(runtime.GOROOT(), "src", pkg))
 	isStdLib := err == nil
 	stdlibLookup[pkg] = &isStdLib
 	return isStdLib


### PR DESCRIPTION
This change replaces the use of the `GOROOT` environment variable with the more robust `runtime.GOROOT()` method from the stdlib.

This is because Taskrunner will currently fail to find packages from the stdlib if GOROOT is not explicitly defined in an environment variable when using Go Modules.