### PR TITLE
runner: use tabwriter to format --describe

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/taskrunner/config"
@@ -113,11 +114,15 @@ func Run(options ...RunOption) {
 	}
 
 	if describeTasks {
-		var outputString string
+		w := tabwriter.NewWriter(os.Stdout, 0, 3, 0, ' ', 0)
+
+		fmt.Fprintln(w, "\tTask name\tDescription")
 		for _, task := range tasks {
-			outputString = fmt.Sprintf("%s\n\t%s\t %s", outputString, task.Name, task.Description)
+			fmt.Fprintf(w, "\t%s\t%s\n", task.Name, task.Description)
 		}
-		fmt.Println(outputString)
+		if err := w.Flush(); err != nil {
+			log.Fatalf("unable to flush tabwriter: \n%v\n", err)
+		}
 		return
 	}
 


### PR DESCRIPTION
noticed the `--describe` output is kinda messy and could benefit from tabwriter's consistent spacing

tested this manually with the screenshots below.

before:
<img width="1513" alt="Screen Shot 2020-10-13 at 9 58 40 AM" src="https://user-images.githubusercontent.com/11747956/95892051-c63bbc80-0d3a-11eb-9d47-3ebc7763791a.png">

after:
<img width="1490" alt="Screen Shot 2020-10-13 at 9 58 18 AM" src="https://user-images.githubusercontent.com/11747956/95892078-cdfb6100-0d3a-11eb-8478-59d4354a5852.png">
