### PR TITLE
task,runner: allow tasks to be marked as Hidden

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -18,6 +18,7 @@ var (
 	configFile     string
 	nonInteractive bool
 	listTasks      bool
+	listAllTasks   bool
 	watch          bool
 	describeTasks  bool
 )
@@ -46,7 +47,8 @@ func newRuntime() *Runtime {
 	}
 	r.flags.StringVar(&configFile, "config", "", "Configuration file to use")
 	r.flags.BoolVar(&nonInteractive, "non-interactive", false, "Non-interactive mode (only applies when running the default set of tasks)")
-	r.flags.BoolVar(&listTasks, "list", false, "List all tasks")
+	r.flags.BoolVar(&listTasks, "list", false, "List all tasks except those marked \"Hidden\"")
+	r.flags.BoolVar(&listAllTasks, "listAll", false, "List all tasks including those marked as \"Hidden\"")
 	r.flags.BoolVar(&watch, "watch", false, "Run in watch mode (only applies when passing custom tasks)")
 	r.flags.BoolVar(&describeTasks, "describe", false, "Describe all tasks")
 
@@ -104,9 +106,16 @@ func Run(options ...RunOption) {
 
 	tasks := runtime.registry.Tasks()
 
-	if listTasks {
+	if listTasks && listAllTasks {
+		log.Fatalf("--list and --listAll cannot be specified at the same time. Please only use one.")
+	}
+
+	if listTasks || listAllTasks {
 		outputString := "Run specified tasks with `taskrunner taskname1 taskname2`\nTasks available:"
 		for _, task := range tasks {
+			if listTasks && task.Hidden {
+				continue
+			}
 			outputString = outputString + "\n\t" + task.Name
 		}
 		fmt.Println(outputString)

--- a/task.go
+++ b/task.go
@@ -29,6 +29,9 @@ type Task struct {
 	// If true, this task will be restarted when it exits, regardless of exit code.
 	KeepAlive bool
 
+	// Hidden specifies whether or not to show the task when -list is called.
+	Hidden bool
+
 	// Sources specifies globs that this task depends on. When those files change,
 	// the task will be invalidated.
 	Sources []string


### PR DESCRIPTION
This will allow us to set a task to Hidden. To start, this will indicate
if a task will be shown in -list or -listall in taskrunner.

This will help avoid devs from using tasks that aren't meant to be
called. For example, in taskrunner devbox/run there are multiple
commands that we want to run in parallel, but could easily be confused
for devbox/run. While if devs truly want to they will still be able to
see all the tasks via -listall.

In the future, this could be used for ordering within the TUI.

## How did I test this?
I updated my vendor locally, I ran -list and then changed the /buid tasks, then set `Hidden` to true and then reran -list
```
❯ taskrunner -list | rg build | wc -l
515
❯ taskrunner -list | rg build | wc -l
27
❯ taskrunner -listall | rg build | wc -l
515
```