### PR TITLE
Tonia/support task flags

### DIFF
--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -1,0 +1,290 @@
+package taskrunner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/samsarahq/taskrunner/config"
+	"github.com/samsarahq/taskrunner/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(i bool) *bool {
+	return &i
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func float64Ptr(i float64) *float64 {
+	return &i
+}
+
+func stringPtr(i string) *string {
+	return &i
+}
+
+func durationPtr(i time.Duration) *time.Duration {
+	return &i
+}
+
+func TestParseTaskOptionsListToMap(t *testing.T) {
+	config := &config.Config{}
+	mockRunWithFlags := func(ctx context.Context, shellRun shell.ShellRun, flags map[string]FlagArg) error {
+		return nil
+	}
+
+	taskFlagA := TaskFlag{
+		Description: "This is a description of what bool flag A does.",
+		LongName:    "flagA",
+		ShortName:   []rune("a")[0],
+		ValueType:   BoolTypeFlag,
+		Default:     "true",
+	}
+	taskFlagB := TaskFlag{
+		Description: "This is a description of what string flag B does.",
+		ShortName:   []rune("b")[0],
+		ValueType:   StringTypeFlag,
+		Default:     "presidential dolphin",
+	}
+	taskFlagC := TaskFlag{
+		Description: "This is a description of what int flag C does.",
+		ShortName:   []rune("c")[0],
+		ValueType:   IntTypeFlag,
+		Default:     "10",
+	}
+	taskFlagD := TaskFlag{
+		Description: "This is a description of what float64 flag D does.",
+		ShortName:   []rune("d")[0],
+		ValueType:   Float64TypeFlag,
+		Default:     "1.72",
+	}
+	taskFlagE := TaskFlag{
+		Description: "This is a description of what duration flag E does.",
+		ShortName:   []rune("e")[0],
+		ValueType:   DurationTypeFlag,
+		Default:     "11h",
+	}
+	taskFlagF := TaskFlag{
+		Description: "This is a description of what duration flag F does.",
+		ShortName:   []rune("f")[0],
+		ValueType:   BoolTypeFlag,
+	}
+	mockTaskName := "mock/task/1"
+	mockTask1 := &Task{
+		Name:         mockTaskName,
+		RunWithFlags: mockRunWithFlags,
+		Flags:        []TaskFlag{taskFlagA, taskFlagB, taskFlagC, taskFlagD, taskFlagE},
+	}
+	mockTaskFlagRegistry := map[string]map[string]TaskFlag{
+		mockTaskName: {
+			"flagA": taskFlagA,
+			"a":     taskFlagA,
+			"b":     taskFlagB,
+			"c":     taskFlagC,
+			"d":     taskFlagD,
+			"e":     taskFlagE,
+			"f":     taskFlagF,
+		},
+	}
+
+	tasks := []*Task{mockTask1}
+	testCases := []struct {
+		description          string
+		flagArgs             []string
+		expectedFlagAVal     *bool
+		expectedLongFlagAVal *bool
+		expectedFlagBVal     *string
+		expectedFlagCVal     *int
+		expectedFlagDVal     *float64
+		expectedFlagEVal     *time.Duration
+		expectFlagFValIsNil  bool
+		invalidFlagPanicVal  string
+	}{
+		{
+			description:          "Should parse BoolTypeFlags correctly and include value for both Short and Long Names",
+			flagArgs:             []string{"-a"},
+			expectedFlagAVal:     boolPtr(true),
+			expectedLongFlagAVal: boolPtr(true),
+		},
+		{
+			description:      "Should parse String/Duration/Int/Float64TypeFlags wrapped in \"\"s correctly",
+			flagArgs:         []string{"-b=\"test\"", "-c=\"1\"", "-d=\"1.3\"", "-e=\"10h\""},
+			expectedFlagBVal: stringPtr("test"),
+			expectedFlagCVal: intPtr(1),
+			expectedFlagDVal: float64Ptr(1.3),
+			expectedFlagEVal: durationPtr(time.Duration(10 * time.Hour)),
+		},
+		{
+			description:      "Should parse String/Duration/Int/Float64TypeFlags not wrapped in \"\"s correctly",
+			flagArgs:         []string{"-b=test", "-c=1", "-d=1.3", "-e=10h"},
+			expectedFlagBVal: stringPtr("test"),
+			expectedFlagCVal: intPtr(1),
+			expectedFlagDVal: float64Ptr(1.3),
+			expectedFlagEVal: durationPtr(time.Duration(10 * time.Hour)),
+		},
+		{
+			description:      "Should respect Default str value if no arg passed to variable flag",
+			flagArgs:         []string{"-b"},
+			expectedFlagBVal: stringPtr("presidential dolphin"),
+		},
+		{
+			description:      "Should respect Default int value if no arg passed to variable flag",
+			flagArgs:         []string{"-c"},
+			expectedFlagCVal: intPtr(10),
+		},
+		{
+			description:      "Should respect Default float64 value if no arg passed to variable flag",
+			flagArgs:         []string{"-d"},
+			expectedFlagDVal: float64Ptr(1.72),
+		},
+		{
+			description:      "Should respect Default duration value if no arg passed to variable flag",
+			flagArgs:         []string{"-e"},
+			expectedFlagEVal: durationPtr(time.Duration(11 * time.Hour)),
+		},
+		{
+			description:         "Should return nil if no arg passed to variable flag and no Default defined",
+			flagArgs:            []string{"-f"},
+			expectFlagFValIsNil: true,
+		},
+		{
+			description:          "Should store Default values for all flags and Value nil when no args are passed",
+			flagArgs:             []string{},
+			expectedFlagAVal:     boolPtr(true),
+			expectedLongFlagAVal: boolPtr(true),
+			expectedFlagBVal:     stringPtr("presidential dolphin"),
+			expectedFlagCVal:     intPtr(10),
+			expectedFlagDVal:     float64Ptr(1.72),
+			expectFlagFValIsNil:  true,
+		},
+		{
+			description:         "Should panic if there are multiple `=`s in the flag",
+			flagArgs:            []string{"-b=\"testing\"=\"testing123\""},
+			invalidFlagPanicVal: "Invalid flag syntax for mock/task/1: `-b=\"testing\"=\"testing123\"`",
+		},
+		{
+			description:         "Should panic if an unsupported flag is passed",
+			flagArgs:            []string{"--invalidFlag"},
+			invalidFlagPanicVal: "Unsupported flag passed to mock/task/1: `--invalidFlag`. See error: Unsupported flag: --invalidFlag",
+		},
+		{
+			description: "Should panic if not possible to cast string to int for IntTypeFlag args",
+			flagArgs:    []string{"-c=\"\"00\"10\"b\"\""},
+		},
+		{
+			description: "Should panic if not possible to cast string to float64 for Float64TypeFlag args",
+			flagArgs:    []string{"-d=\"\"00\"10.3\"b\"\""},
+		},
+		{
+			description: "Should panic if not possible to cast string to duration for DurationTypeFlag args",
+			flagArgs:    []string{"-e=\"\"00\"10.3\"b\"\"09m"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			executorOptions := []ExecutorOption{
+				func(e *Executor) {
+					e.taskFlagArgs = map[string][]string{
+						mockTaskName: tc.flagArgs,
+					}
+				},
+				func(e *Executor) {
+					e.taskFlagsRegistry = mockTaskFlagRegistry
+				},
+			}
+
+			executor := NewExecutor(config, tasks, executorOptions...)
+			if tc.invalidFlagPanicVal != "" {
+				assert.PanicsWithValue(t, tc.invalidFlagPanicVal, func() { executor.parseTaskFlagsIntoMap(mockTaskName, tc.flagArgs) })
+			} else {
+				flagsMap := executor.parseTaskFlagsIntoMap(mockTaskName, tc.flagArgs)
+				if tc.expectedFlagAVal != nil {
+					assert.Equal(t, *tc.expectedFlagAVal, *flagsMap["a"].BoolVal())
+					assert.Equal(t, *tc.expectedLongFlagAVal, *flagsMap["flagA"].BoolVal())
+
+					flagArgShort := flagsMap["a"]
+					assert.Panics(t, func() { flagArgShort.IntVal() })
+					assert.Panics(t, func() { flagArgShort.StringVal() })
+					assert.Panics(t, func() { flagArgShort.Float64Val() })
+					assert.Panics(t, func() { flagArgShort.DurationVal() })
+
+					flagArgLong := flagsMap["flagA"]
+					assert.Panics(t, func() { flagArgLong.IntVal() })
+					assert.Panics(t, func() { flagArgLong.StringVal() })
+					assert.Panics(t, func() { flagArgLong.Float64Val() })
+					assert.Panics(t, func() { flagArgLong.DurationVal() })
+
+					if len(tc.flagArgs) == 0 {
+						assert.Nil(t, flagArgShort.Value)
+						assert.Nil(t, flagArgLong.Value)
+					}
+				}
+
+				if tc.expectedFlagBVal != nil {
+					assert.Equal(t, *tc.expectedFlagBVal, *flagsMap["b"].StringVal())
+
+					flagArg := flagsMap["b"]
+					assert.Panics(t, func() { flagArg.IntVal() })
+					assert.Panics(t, func() { flagArg.BoolVal() })
+					assert.Panics(t, func() { flagArg.Float64Val() })
+					assert.Panics(t, func() { flagArg.DurationVal() })
+
+					if len(tc.flagArgs) == 0 {
+						assert.Nil(t, flagArg.Value)
+					}
+				}
+
+				if tc.expectedFlagCVal != nil {
+					assert.Equal(t, *tc.expectedFlagCVal, *flagsMap["c"].IntVal())
+
+					flagArg := flagsMap["c"]
+					assert.Panics(t, func() { flagArg.StringVal() })
+					assert.Panics(t, func() { flagArg.BoolVal() })
+					assert.Panics(t, func() { flagArg.Float64Val() })
+					assert.Panics(t, func() { flagArg.DurationVal() })
+
+					if len(tc.flagArgs) == 0 {
+						assert.Nil(t, flagArg.Value)
+					}
+				}
+
+				if tc.expectedFlagDVal != nil {
+					assert.Equal(t, *tc.expectedFlagDVal, *flagsMap["d"].Float64Val())
+
+					flagArg := flagsMap["d"]
+					assert.Panics(t, func() { flagArg.StringVal() })
+					assert.Panics(t, func() { flagArg.BoolVal() })
+					assert.Panics(t, func() { flagArg.IntVal() })
+					assert.Panics(t, func() { flagArg.DurationVal() })
+
+					if len(tc.flagArgs) == 0 {
+						assert.Nil(t, flagArg.Value)
+					}
+				}
+
+				if tc.expectedFlagEVal != nil {
+					assert.Equal(t, *tc.expectedFlagEVal, *flagsMap["e"].DurationVal())
+
+					flagArg := flagsMap["e"]
+					assert.Panics(t, func() { flagArg.StringVal() })
+					assert.Panics(t, func() { flagArg.BoolVal() })
+					assert.Panics(t, func() { flagArg.IntVal() })
+					assert.Panics(t, func() { flagArg.Float64Val() })
+
+					if len(tc.flagArgs) == 0 {
+						assert.Nil(t, flagArg.Value)
+					}
+				}
+
+				if tc.expectFlagFValIsNil {
+					flagArg := flagsMap["f"]
+					assert.Nil(t, flagArg.BoolVal())
+				}
+			}
+		})
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -13,12 +13,14 @@ var DefaultRegistry = NewRegistry()
 func NewRegistry() *Registry {
 	return &Registry{
 		definitions: make(map[string]*Task),
+		flagsByTask: make(map[string]map[string]TaskFlag),
 	}
 }
 
 // Registry is an object that keeps track of task definitions.
 type Registry struct {
 	definitions map[string]*Task
+	flagsByTask map[string]map[string]TaskFlag
 }
 
 type TaskOption func(*Task) *Task
@@ -31,7 +33,75 @@ func (r *Registry) Add(t *Task, opts ...TaskOption) *Task {
 	if _, ok := r.definitions[t.Name]; ok {
 		panic(fmt.Sprintf("Duplicate task registered: %s", t.Name))
 	}
+	// Validate that both Run and RunWithFlags are not defined,
+	// displaying a message that prefers RunWithFlags over the deprecated Run.
+	if t.Run != nil && t.RunWithFlags != nil {
+		panic(fmt.Sprintf("Both `Run` and `RunWithFlags` are defined on the `%s` task. `Run` is deprecated, please prefer using `RunWithFlags`.", t.Name))
+	}
+
 	r.definitions[t.Name] = t
+
+	r.flagsByTask[t.Name] = map[string]TaskFlag{}
+	for _, flag := range t.Flags {
+		// Validate that the task Name does not match any of its flag Long/ShortNames.
+		if t.Name == flag.LongName {
+			panic(fmt.Sprintf("Task name `%s` and flag LongName `%s` are currently duplicates. Please de-depulicate their names.", t.Name, flag.LongName))
+		}
+
+		if t.Name == string(flag.ShortName) {
+			panic(fmt.Sprintf("Task name `%s` and flag ShortName `%s` are currently duplicates. Please de-depulicate their names.", t.Name, string(flag.ShortName)))
+		}
+
+		// Validate that the following task TaskFlag fields are provided:
+		// - LongName or ShortName
+		// - Disallow --help/-h flags
+		// - Description
+		// - ValueType
+		if flag.LongName == "" && flag.ShortName == 0 {
+			panic(fmt.Sprintf("Neither LongName nor ShortName are defined for a flag on `%s`. At least one name must be defined.", t.Name))
+		}
+
+		if flag.LongName == "help" {
+			panic("The LongFlag name `help` is reserved.")
+		}
+
+		if string(flag.ShortName) == "h" {
+			panic("The ShortFlag name `h` is reserved.")
+		}
+
+		if flag.Description == "" {
+			var optionName string
+			if flag.LongName != "" {
+				optionName = flag.LongName
+			} else {
+				optionName = string(flag.ShortName)
+			}
+			panic(fmt.Sprintf("Please provide a description for the `%s` flag.", optionName))
+		}
+
+		if flag.ValueType != StringTypeFlag && flag.ValueType != BoolTypeFlag && flag.ValueType != IntTypeFlag && flag.ValueType != Float64TypeFlag && flag.ValueType != DurationTypeFlag {
+			panic("Please set the flag ValueType with `taskrunner.StringTypeFlag`, `taskrunner.BoolTypeFlag`, `taskrunner.DurationTypeFlag`, `taskrunner.Float64TypeFlag` or `taskrunner.IntTypeFlag`.")
+		}
+
+		// Validate that there are no duplicate LongNames.
+		if flag.LongName != "" {
+			_, ok := r.flagsByTask[t.Name][flag.LongName]
+			if ok {
+				panic(fmt.Sprintf("Duplicate flag LongName registered: `%s`.", flag.LongName))
+			}
+			r.flagsByTask[t.Name][flag.LongName] = flag
+		}
+
+		// Validate that there are no duplicate ShortNames.
+		if flag.ShortName != 0 {
+			_, ok := r.flagsByTask[t.Name][string(flag.ShortName)]
+			if ok {
+				panic(fmt.Sprintf("Duplicate flag ShortName registered: `%s`.", string(flag.ShortName)))
+			}
+			r.flagsByTask[t.Name][string(flag.ShortName)] = flag
+		}
+	}
+
 	return t
 }
 

--- a/registry_internal_test.go
+++ b/registry_internal_test.go
@@ -1,0 +1,226 @@
+package taskrunner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samsarahq/taskrunner/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	mockRunWithFlags := func(ctx context.Context, shellRun shell.ShellRun, flags map[string]FlagArg) error {
+		return nil
+	}
+
+	testCases := []struct {
+		description string
+		shouldPanic bool
+		mockTask    *Task
+		panicVal    string
+	}{
+		{
+			description: "Should panic if both Run and RunWithFlags is defined",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Run:          func(ctx context.Context, shellRun shell.ShellRun) error { return nil },
+			},
+			panicVal: "Both `Run` and `RunWithFlags` are defined on the `mock/task/1` task. `Run` is deprecated, please prefer using `RunWithFlags`.",
+		},
+		{
+			description: "Should panic if task Name matches flag LongName",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						LongName:  "mock/task/1",
+						ValueType: BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "Task name `mock/task/1` and flag LongName `mock/task/1` are currently duplicates. Please de-depulicate their names.",
+		},
+		{
+			description: "Should panic if task Name matches flag ShortName",
+			mockTask: &Task{
+				Name:         "a",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						ShortName: []rune("a")[0],
+						ValueType: BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "Task name `a` and flag ShortName `a` are currently duplicates. Please de-depulicate their names.",
+		},
+		{
+			description: "Should panic if a flag is missing a description",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						LongName:  "flagA",
+						ValueType: BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "Please provide a description for the `flagA` flag.",
+		},
+		{
+			description: "Should panic if a flag is missing a ValueType",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						LongName:    "flagA",
+					},
+				},
+			},
+			panicVal: "Please set the flag ValueType with `taskrunner.StringTypeFlag`, `taskrunner.BoolTypeFlag`, `taskrunner.DurationTypeFlag`, `taskrunner.Float64TypeFlag` or `taskrunner.IntTypeFlag`.",
+		},
+		{
+			description: "Should panic if a flag has a ValueType that does not match XTypeFlag",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						LongName:    "flagA",
+						ValueType:   "thisIsInvalid",
+					},
+				},
+			},
+			panicVal: "Please set the flag ValueType with `taskrunner.StringTypeFlag`, `taskrunner.BoolTypeFlag`, `taskrunner.DurationTypeFlag`, `taskrunner.Float64TypeFlag` or `taskrunner.IntTypeFlag`.",
+		},
+		{
+			description: "Should panic if a flag lacks both a LongName and ShortName",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						ValueType:   BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "Neither LongName nor ShortName are defined for a flag on `mock/task/1`. At least one name must be defined.",
+		},
+		{
+			description: "Should panic if there are duplicate flag LongNames",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						LongName:    "flagA",
+						ValueType:   BoolTypeFlag,
+					},
+					{
+						Description: "This is a description of flagA",
+						LongName:    "flagA",
+						ValueType:   BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "Duplicate flag LongName registered: `flagA`.",
+		},
+		{
+			description: "Should panic if a there are duplicate flag ShortNames",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						ShortName:   []rune("a")[0],
+						ValueType:   BoolTypeFlag,
+					},
+					{
+						Description: "This is a description of flagA",
+						ShortName:   []rune("a")[0],
+						ValueType:   BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "Duplicate flag ShortName registered: `a`.",
+		},
+		{
+			description: "Should panic if reserved `help` long name is used",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						LongName:    "help",
+						ValueType:   BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "The LongFlag name `help` is reserved.",
+		},
+		{
+			description: "Should panic if reserved `h` short name is used",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						ShortName:   []rune("h")[0],
+						ValueType:   BoolTypeFlag,
+					},
+				},
+			},
+			panicVal: "The ShortFlag name `h` is reserved.",
+		},
+		{
+			description: "Should succeed if Description, valid LongName and ValueType exist",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						LongName:    "flagA",
+						ValueType:   BoolTypeFlag,
+					},
+				},
+			},
+		},
+		{
+			description: "Should succeed if Description, valid ShortName and ValueType exist",
+			mockTask: &Task{
+				Name:         "mock/task/1",
+				RunWithFlags: mockRunWithFlags,
+				Flags: []TaskFlag{
+					{
+						Description: "This is a description of flagA",
+						ShortName:   []rune("a")[0],
+						ValueType:   BoolTypeFlag,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		registry := NewRegistry()
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.panicVal != "" {
+				assert.PanicsWithValue(t, tc.panicVal, func() { registry.Add(tc.mockTask) })
+			} else {
+				assert.NotPanics(t, func() { registry.Add(tc.mockTask) })
+			}
+		})
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -188,6 +188,14 @@ func Run(options ...RunOption) {
 		watchMode = watch
 	}
 
+	// Set task/option groups on executor
+	ExecutorOptions(func(e *Executor) {
+		e.taskFlagArgs = taskFlagGroups
+	})(runtime)
+	// Set supported task options registry on executor
+	ExecutorOptions(func(e *Executor) {
+		e.taskFlagsRegistry = runtime.registry.flagsByTask
+	})(runtime)
 	executorOptions := append([]ExecutorOption{WithWatchMode(watchMode)}, runtime.executorOptions...)
 	executor := NewExecutor(c, tasks, executorOptions...)
 

--- a/runner.go
+++ b/runner.go
@@ -82,6 +82,45 @@ func ExecutorOptions(opts ...ExecutorOption) RunOption {
 	}
 }
 
+// groupTaskAndFlagArgs groups all tasks with their flag arguments.
+// Notably, this function does not group flags passed to taskrunner itself.
+// Those flags are stored via the flags package and are handled separately.
+func (r *Runtime) groupTaskAndFlagArgs(args []string) map[string][]string {
+	flagArgsPerTask := map[string][]string{}
+
+	var currTaskName string
+	var currFlagsList []string
+	for _, arg := range args {
+		// Check task registry to figure out whether the arg is a task or a flag.
+		val, ok := r.registry.definitions[arg]
+		if ok {
+			if currTaskName == "" {
+				// If this is the first task, we've found, set the currTaskName.
+				currTaskName = val.Name
+			} else {
+				// If this is a new task we've found, store the flags we've collected for prev task.
+				flagArgsPerTask[currTaskName] = currFlagsList
+				currTaskName = val.Name
+				currFlagsList = []string{}
+			}
+		} else if currTaskName != "" {
+			// If we have identified a current task and we are sure the arg is a flag,
+			// add it to the list of flags we are storing for the current task.
+			// Notably, if the first flags are options to taskrunner, currTaskName will be ""
+			// and we will not group those flags with any tasks.
+			currFlagsList = append(currFlagsList, arg)
+		}
+	}
+
+	// Ensure the we register the flags passed to the last task.
+	if currTaskName != "" {
+		flagArgsPerTask[currTaskName] = currFlagsList
+	}
+
+	// Return map of task to list of flags passed to it.
+	return flagArgsPerTask
+}
+
 func Run(options ...RunOption) {
 	runtime := newRuntime()
 	for _, option := range options {
@@ -136,13 +175,16 @@ func Run(options ...RunOption) {
 	}
 
 	log.Println("Using config", c.ConfigPath)
+	taskFlagGroups := runtime.groupTaskAndFlagArgs(os.Args[1:])
 	var desiredTasks []string
+	for taskName := range taskFlagGroups {
+		desiredTasks = append(desiredTasks, taskName)
+	}
 	var watchMode bool
-	if len(runtime.flags.Args()) == 0 {
+	if len(desiredTasks) == 0 {
 		desiredTasks = c.DesiredTasks
 		watchMode = !nonInteractive
 	} else {
-		desiredTasks = runtime.flags.Args()
 		watchMode = watch
 	}
 

--- a/runner_internal_test.go
+++ b/runner_internal_test.go
@@ -1,0 +1,113 @@
+package taskrunner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samsarahq/taskrunner/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunnerGroupTaskAndFlagArgs(t *testing.T) {
+	mockRunWithFlags := func(ctx context.Context, shellRun shell.ShellRun, flags map[string]FlagArg) error {
+		return nil
+	}
+	mockTask1 := &Task{
+		Name:         "mock/task/1",
+		RunWithFlags: mockRunWithFlags,
+		Flags: []TaskFlag{
+			{
+				Description: "This is a description of what the bool flag A does.",
+				LongName:    "longFlagA",
+				ShortName:   []rune("a")[0],
+				ValueType:   BoolTypeFlag,
+			},
+			{
+				Description: "This is a description of what the bool flag B does.",
+				LongName:    "longFlagB",
+				ShortName:   []rune("b")[0],
+				ValueType:   BoolTypeFlag,
+			},
+		},
+	}
+	mockTask2 := &Task{
+		Name:         "mock/task/2",
+		RunWithFlags: mockRunWithFlags,
+		Flags: []TaskFlag{
+			{
+				Description: "This is a description of what string flag C does.",
+				ShortName:   []rune("c")[0],
+				ValueType:   StringTypeFlag,
+			},
+		},
+	}
+	mockTask3 := &Task{
+		Name:         "mock/task/3",
+		RunWithFlags: mockRunWithFlags,
+		Flags: []TaskFlag{
+			{
+				Description: "This is a description of what int flag D does.",
+				ShortName:   []rune("d")[0],
+				ValueType:   IntTypeFlag,
+			},
+		},
+	}
+
+	testCases := []struct {
+		description    string
+		cliArgs        []string
+		expectedGroups map[string][]string
+	}{
+		{
+			description: "Should group single flag to single task",
+			cliArgs:     []string{"mock/task/1", "--longFlagA"},
+			expectedGroups: map[string][]string{
+				"mock/task/1": {"--longFlagA"},
+			},
+		},
+		{
+			description: "Should group multiple flags (long or short) to single task",
+			cliArgs:     []string{"mock/task/1", "--longFlagA", "-b"},
+			expectedGroups: map[string][]string{
+				"mock/task/1": {"--longFlagA", "-b"},
+			},
+		},
+		{
+			description: "Should group multiple flags to multiple tasks",
+			cliArgs:     []string{"mock/task/1", "--longFlagA", "-b", "mock/task/2", "-c='test'", "mock/task/3", "-d=1"},
+			expectedGroups: map[string][]string{
+				"mock/task/1": {"--longFlagA", "-b"},
+				"mock/task/2": {"-c='test'"},
+				"mock/task/3": {"-d=1"},
+			},
+		},
+		{
+			description: "Should exclude tasks passed directly to taskrunner",
+			cliArgs:     []string{"--config", "mock/task/1", "--longFlagA"},
+			expectedGroups: map[string][]string{
+				"mock/task/1": {"--longFlagA"},
+			},
+		},
+		{
+			// Validation for supported flags happens in the executor.
+			description: "Should include unsupported flag args in group",
+			cliArgs:     []string{"mock/task/1", "--longInvalidFlag"},
+			expectedGroups: map[string][]string{
+				"mock/task/1": {"--longInvalidFlag"},
+			},
+		},
+	}
+
+	runner := newRuntime()
+	runner.registry.Add(mockTask1)
+	runner.registry.Add(mockTask2)
+	runner.registry.Add(mockTask3)
+
+	for _, tc := range testCases {
+		taskFlagGroups := runner.groupTaskAndFlagArgs(tc.cliArgs)
+		for key, val := range taskFlagGroups {
+			flags := tc.expectedGroups[key]
+			assert.ElementsMatch(t, flags, val)
+		}
+	}
+}

--- a/task.go
+++ b/task.go
@@ -2,6 +2,7 @@ package taskrunner
 
 import (
 	"context"
+	"time"
 
 	"github.com/samsarahq/taskrunner/shell"
 )
@@ -15,9 +16,19 @@ type Task struct {
 	// XXX: Pass files in so that task can decide to do less work, i.e. if
 	// you change a go file we can run go fmt on just that file.
 
+	// [DEPRECATED] This fn is deprecated in favor of RunWithFlags
 	// Run is called when the task should be run. The function should gracefully
 	// handle context cancelation.
 	Run func(ctx context.Context, shellRun shell.ShellRun) error
+
+	// RunWithFlags is called when the task should be run
+	// and includes all flags passed to the task. The function
+	// should gracefully handle context cancellation.
+	RunWithFlags func(ctx context.Context, shellRun shell.ShellRun, flagArgs map[string]FlagArg) error
+
+	// Flags is a list of supported flags for this task (e.g. --var="val", -bool).
+	// Only the flags specified in this list will be considered valid arguments to a task.
+	Flags []TaskFlag
 
 	ShouldInvalidate func(event InvalidationEvent) bool
 
@@ -42,4 +53,47 @@ type Task struct {
 	// IsGroup specifies whether this task is a pseudo-task that groups
 	// other tasks underneath it.
 	IsGroup bool
+}
+
+type TaskFlag struct {
+	// Description should be a string that describes what effect passing the flag to a task has.
+	// This description is shown automatically in the generated --help message.
+	// This field must be non-empty.
+	Description string
+
+	// ShortName is the single character version of the flag. If not 0, the
+	// option flag can be 'activated' using -<ShortName>. Either ShortName
+	// or LongName needs to be non-empty.
+	ShortName rune
+
+	// LongName is the multi-character version of the flag. If not "", the flag can be
+	// activated using --<LongName>. Either ShortName or LongName needs to be non-empty.
+	LongName string
+
+	// Default is the default value for the flag.
+	Default string
+
+	// ValueType describes what the flag type is (e.g. --flag [ValueType])
+	// and can be one of either: StringTypeFlag, BoolTypeFlag,
+	// IntTypeFlag, Float64TypeFlag, or DurationTypeFlag.
+	// Its value is shown automatically in the generated --help message.
+	// This field must be non-empty.
+	ValueType string
+}
+
+const (
+	StringTypeFlag   string = "string"
+	BoolTypeFlag     string = "bool"
+	IntTypeFlag      string = "int"
+	Float64TypeFlag  string = "float64"
+	DurationTypeFlag string = "duration"
+)
+
+type FlagArg struct {
+	Value       interface{}
+	StringVal   func() *string
+	BoolVal     func() *bool
+	IntVal      func() *int
+	Float64Val  func() *float64
+	DurationVal func() *time.Duration
 }


### PR DESCRIPTION
We would like to support passing flags to a task via CLI
(e.g. taskrunner task/name --option, taskrunner task/name --key="val")

Update the Task type to include a Flags field which allows
devs to specify a list of supported flags on the task definition.

Every specified flag has the following fields:
* Description - a description of the flag's effect
* LongName - the multi-char flag name
* ShortName - the single-char flag name (specified by rune)
* Default - the default value of the flag
* ValueType - the type of value the flag specifies (bool/int/string)

Since we only expect flags to specify bool/int/string types,
we have provided the following enum for ValueType:
* StringTypeFlag
* BoolTypeFlag
* IntTypeFlag
* Float64TypeFlag
* DurationTypeFlag

Eventually, we will pass the flags passed to the task via CLI args
into the RunWithOptions fn as a third argument of type map[string]FlagArg
which will include helper fns to cast the string CLI arg into its
correct type (depending on ValueType).

The OptionArg includes the following fields:
* Value - raw value collected from os.Args
* StringVal - helper fn that returns ptr to string val for string flags
* BoolVal - helper fn that returns ptr to bool val for bool flags
* IntVal - helper fn that returns ptr to int val for int flags
* Float64Val - helper fn that returns ptr to float64 val for float64 flags
* DurationVal - helper fn that returns ptr to time.Duration for duration flags

Eventually, we will pass the flags passed to the task via CLI args
into the RunWithOptions fn as a third argument of type map[string]FlagArg
which will include helper fns to cast the string CLI arg into its
correct type (depending on ValueType).

The OptionArg includes the following fields:
* Value - raw value collected from os.Args
* BoolVal - helper fn that returns bool val for bool options
* IntVal - helper fn that returns int val for int options
* StringVal - helper fn that returns sting val for string options

----

Ensure that only Run or RunWithFlags is passed, panicing and displaying
a message that lets the dev know that Run is deprecated in favor of
RunWithFlags.

Ensure that flag Long/ShortNames are not dupes/shadows of the task name.

When adding a task to the task registry, validate that all options
specified in the task Flags field:
* Have either a LongName or ShortName specified
* Do not use the reserved "help"/"h" LongName and ShortName
* Include a Description
* Include a ValueType that matches the String/Bool/IntFlagType enum vals

Additionally, ensure that no duplicate LongName or ShortName flags exist
for the same task.

----

Update the runner to create and store flags passed via CLI by
the desired task.

Note that all flags passed directly to taskrunner (e.g. config, list, etc.)
are handled via the flag package and extracted/handled separately from
the task flags.

Eventually, we will pass desired tasks and task flags to the executor
which will handle parsing them into a map[string]FlagArg that will be
passed into a task's RunWithFlags fn.

----

Update executor to also store:
* taskFlagsRegistry - groups all supported flags by task
* taskFlagArgs - groups all passed flags by task

Create default map of flag name to FlagArgs using supported
flags and Default values.

Then parse all flag args passed to the task into the map of FlagArgs,
overriding default values with used passed args/values.
Parsing the passed flags includes verifying that the flags are
supported before converting the list into the map.

Helper fns to cast the original string arg into the relevant types
depending on the TaskFlag's ValueType. If the incorrect
fns are used for the option's ValueType, panic and warn
dev to use the correct helper fn according to the option ValueType.

Eventually pass the map of FlagArgs into the RunWithFlags fn
as the third argument.

---

If a user passes a desired task with the flag "--help"/"-h", automatically
generate a help message that describes all the supported task flags for all
tasks that the help flag was passed to and do not execute
any of the desired tasks.

`taskrunner silly/mock/task --help goofy/mock/task -h fun/mock/task`
![Screenshot 2023-02-01 at 12 10 21 PM](https://user-images.githubusercontent.com/16676111/216127213-2df519f6-6ab3-4923-b0a5-1a355a18861d.png)

