### PR TITLE
taskrunner runner: include invalid task names in desired task set

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -91,24 +91,19 @@ func (r *Runtime) groupTaskAndFlagArgs(args []string) map[string][]string {
 	var currTaskName string
 	var currFlagsList []string
 	for _, arg := range args {
-		// Check task registry to figure out whether the arg is a task or a flag.
-		val, ok := r.registry.definitions[arg]
-		if ok {
-			if currTaskName == "" {
-				// If this is the first task, we've found, set the currTaskName.
-				currTaskName = val.Name
-			} else {
-				// If this is a new task we've found, store the flags we've collected for prev task.
-				flagArgsPerTask[currTaskName] = currFlagsList
-				currTaskName = val.Name
-				currFlagsList = []string{}
-			}
-		} else if currTaskName != "" {
-			// If we have identified a current task and we are sure the arg is a flag,
+		if currTaskName != "" && (strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--")) {
+			// If we have identified a current task and we think the arg is a flag,
 			// add it to the list of flags we are storing for the current task.
 			// Notably, if the first flags are options to taskrunner, currTaskName will be ""
 			// and we will not group those flags with any tasks.
 			currFlagsList = append(currFlagsList, arg)
+		} else {
+			if currTaskName != "" {
+				// If this arg is a new task, store the flags we've collected for prev task.
+				flagArgsPerTask[currTaskName] = currFlagsList
+			}
+			currTaskName = arg
+			currFlagsList = []string{}
 		}
 	}
 

--- a/runner_internal_test.go
+++ b/runner_internal_test.go
@@ -96,6 +96,14 @@ func TestRunnerGroupTaskAndFlagArgs(t *testing.T) {
 				"mock/task/1": {"--longInvalidFlag"},
 			},
 		},
+		{
+			// Validation for supported tasks happens in the executor.
+			description: "Should include unsupported task names in group",
+			cliArgs:     []string{"thisisnotarealtask", "--longInvalidFlag"},
+			expectedGroups: map[string][]string{
+				"thisisnotarealtask": {"--longInvalidFlag"},
+			},
+		},
 	}
 
 	runner := newRuntime()


### PR DESCRIPTION
https://samsaradev.atlassian.net/browse/CICD-630

This change fixes a bug where passing an invalid task name as the first argument would not trigger an error (e.g. `taskrunner invalidtask`).

The reason why this was not happening is b/c we were validating whether the args passed to taskrunner and silently leaving them out of the map of desired tasks/flags if they were invalid.

This was especially apparent for invalid task names passed as the first arg since invalid task names passed after a valid task name were treated as flags (and would error as an invalid flag).

Validation happens within the executor, so let's keep that pattern and pass invalid task names as part of the desired tasks we pass into the executor and let validation happen there.

_Before (would just run "taskrunner" as if no args passed)_
![Screenshot 2023-02-23 at 3 39 47 PM](https://user-images.githubusercontent.com/16676111/221036433-2e03c12a-ad04-4d62-8961-fbce6577ae20.png)

_After_
![Screenshot 2023-02-23 at 3 38 55 PM](https://user-images.githubusercontent.com/16676111/221036320-52ea297a-f36b-43d4-aec1-8d72f49a5d81.png)
