### PR TITLE
Tonia/fix flags to tr

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -91,12 +91,15 @@ func (r *Runtime) groupTaskAndFlagArgs(args []string) map[string][]string {
 	var currTaskName string
 	var currFlagsList []string
 	for _, arg := range args {
-		if currTaskName != "" && (strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--")) {
+		isFlag := strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--")
+		if isFlag {
 			// If we have identified a current task and we think the arg is a flag,
 			// add it to the list of flags we are storing for the current task.
 			// Notably, if the first flags are options to taskrunner, currTaskName will be ""
 			// and we will not group those flags with any tasks.
-			currFlagsList = append(currFlagsList, arg)
+			if currTaskName != "" {
+				currFlagsList = append(currFlagsList, arg)
+			}
 		} else {
 			if currTaskName != "" {
 				// If this arg is a new task, store the flags we've collected for prev task.

--- a/runner_internal_test.go
+++ b/runner_internal_test.go
@@ -113,9 +113,18 @@ func TestRunnerGroupTaskAndFlagArgs(t *testing.T) {
 
 	for _, tc := range testCases {
 		taskFlagGroups := runner.groupTaskAndFlagArgs(tc.cliArgs)
+		var expectedTaskGroups []string
+		for key := range tc.expectedGroups {
+			expectedTaskGroups = append(expectedTaskGroups, key)
+		}
+
+		var taskGroups []string
 		for key, val := range taskFlagGroups {
+			taskGroups = append(taskGroups, key)
 			flags := tc.expectedGroups[key]
 			assert.ElementsMatch(t, flags, val)
 		}
+
+		assert.ElementsMatch(t, expectedTaskGroups, taskGroups)
 	}
 }


### PR DESCRIPTION
    taskrunner runner_internal_test: fix test to verify tasks groups

    Due to the type of `expectedGroups` and `taskFlagGroups` (map[string][]string),
    we were not verifying whether the task groups themselves were correct. This is
    b/c indexing by a `key` that did not exist in either the expected or generated
    task groups would result in the default empty array.

    Update test to ensure that the expected task groups and the generated task groups
    are actually correct.

    taskrunner runner: fix bug where we were including flags passed directly to taskrunner

    We were accidentally including any flags passed directly to taskrunner as a task group.

    This resulted in a validation error in the executor.