### PR TITLE
taskrunner runner: add task validation when grouping tasks/flags

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -101,12 +101,18 @@ func (r *Runtime) groupTaskAndFlagArgs(args []string) map[string][]string {
 				currFlagsList = append(currFlagsList, arg)
 			}
 		} else {
+			// If this arg is a new task, store the flags we've collected for prev task.
 			if currTaskName != "" {
-				// If this arg is a new task, store the flags we've collected for prev task.
 				flagArgsPerTask[currTaskName] = currFlagsList
+				currTaskName = ""
+				currFlagsList = []string{}
 			}
-			currTaskName = arg
-			currFlagsList = []string{}
+
+			// If the arg is a valid task, start tracking the taks/flag group.
+			if _, ok := r.registry.definitions[arg]; ok {
+				currTaskName = arg
+				currFlagsList = []string{}
+			}
 		}
 	}
 

--- a/runner_internal_test.go
+++ b/runner_internal_test.go
@@ -82,10 +82,18 @@ func TestRunnerGroupTaskAndFlagArgs(t *testing.T) {
 			},
 		},
 		{
-			description: "Should exclude tasks passed directly to taskrunner",
-			cliArgs:     []string{"--config", "mock/task/1", "--longFlagA"},
+			description: "Should exclude flags and flag args passed directly to taskrunner",
+			cliArgs:     []string{"--config", "pathtoconfig", "--listAll", "--watch", "mock/task/1", "--longFlagA"},
 			expectedGroups: map[string][]string{
 				"mock/task/1": {"--longFlagA"},
+			},
+		},
+		{
+			description: "Should exclude unsupported tasks and any flags passed to it",
+			cliArgs:     []string{"mock/task/1", "--longFlagA", "thisisnotarealtask", "--longInvalidFlag", "mock/task/2", "-c='test'"},
+			expectedGroups: map[string][]string{
+				"mock/task/1": {"--longFlagA"},
+				"mock/task/2": {"-c='test'"},
 			},
 		},
 		{
@@ -94,14 +102,6 @@ func TestRunnerGroupTaskAndFlagArgs(t *testing.T) {
 			cliArgs:     []string{"mock/task/1", "--longInvalidFlag"},
 			expectedGroups: map[string][]string{
 				"mock/task/1": {"--longInvalidFlag"},
-			},
-		},
-		{
-			// Validation for supported tasks happens in the executor.
-			description: "Should include unsupported task names in group",
-			cliArgs:     []string{"thisisnotarealtask", "--longInvalidFlag"},
-			expectedGroups: map[string][]string{
-				"thisisnotarealtask": {"--longInvalidFlag"},
 			},
 		},
 	}


### PR DESCRIPTION
Initially, we solely relied on the executor to validate tasks passed through the CLI as args.

Unfortunately, this makes it difficult to distinguish between whether an arg is an argument to a flag being passed into taskrunner directly (since we allow flag vals to be passed after a space).

To ensure we do not accidentally pass invalid tasks that are meant to be args to taskrunner flags, validate tasks when grouping tasks and flags from the CLI args together.