### PR TITLE
taskrunner logger: if no logger found in ctx, fallback to Printf

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 )
 
 // LoggerFromContext gets the logger from the context.
@@ -45,6 +46,8 @@ func (l *eventLogger) Write(p []byte) (int, error) {
 func Logf(ctx context.Context, f string, args ...interface{}) {
 	logger := LoggerFromContext(ctx)
 	if logger == nil {
+		fmt.Fprintln(os.Stderr, "🟡 Warning: There was no logger found in context, so falling back to `fmt.Printf`")
+		fmt.Printf(f, args...)
 		return
 	}
 


### PR DESCRIPTION
If LoggerFromContext returns nil, then the log is dropped.

Instead of dropping the log, print a warning and fallback to using `fmt.Printf` to ensure:
* The log is still shown
* The developer is warned that no logger was found