### PR TITLE
johnkim/fixCoverageWorkflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Go Get
-        run: |
-          go get
-          go get github.com/mattn/goveralls
       - name: Test
         run: go test -v ./... -coverprofile=coverage.out -covermode=atomic -bench=./...
+      - name: Install Goveralls # this step must come after running the tests, to prevent dependency version conflicts
+        run: |
+          go get github.com/mattn/goveralls
       - name: Send Code Coverage
         uses: shogo82148/actions-goveralls@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,10 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.12.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: '1.12.x'
+          go-version: '1.17.x'
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,29 +1,36 @@
 module github.com/samsarahq/taskrunner
 
-go 1.14
+go 1.17
+
+require (
+	github.com/fatih/color v1.7.1-0.20180516100307-2d684516a886
+	github.com/marcusolsson/tui-go v0.3.1-0.20180616142530-cd94d703fac1
+	github.com/mattn/go-zglob v0.0.1
+	github.com/samsarahq/go v0.0.0-20191220233105-8077c9fbaed5
+	github.com/stretchr/testify v1.2.3-0.20181014000028-04af85275a5c
+	go.uber.org/multierr v1.1.1-0.20180122172545-ddea229ff1df
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	mvdan.cc/sh v2.5.1-0.20180917103936-65d8e2a4b156+incompatible
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.7.1-0.20180516100307-2d684516a886
 	github.com/gdamore/encoding v0.0.0-20151215212835-b23993cbb635 // indirect
 	github.com/gdamore/tcell v1.1.1-0.20181029231221-017915a4d77d // indirect
 	github.com/google/go-cmp v0.4.1 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
 	github.com/lucasb-eyer/go-colorful v0.0.0-20181028223441-12d3b2882a08 // indirect
-	github.com/marcusolsson/tui-go v0.3.1-0.20180616142530-cd94d703fac1
 	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/go-runewidth v0.0.4-0.20181117163326-c88d7e5f2e24 // indirect
-	github.com/mattn/go-zglob v0.0.1
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/samsarahq/go v0.0.0-20191220233105-8077c9fbaed5
 	github.com/smartystreets/goconvey v1.6.4 // indirect
-	github.com/stretchr/testify v1.2.3-0.20181014000028-04af85275a5c
 	go.uber.org/atomic v1.3.3-0.20181018215023-8dc6146f7569 // indirect
-	go.uber.org/multierr v1.1.1-0.20180122172545-ddea229ff1df
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
+	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
 	golang.org/x/text v0.3.1-0.20181030141323-6f44c5a2ea40 // indirect
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
-	mvdan.cc/sh v2.5.1-0.20180917103936-65d8e2a4b156+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -62,7 +62,6 @@ golang.org/x/text v0.3.1-0.20181030141323-6f44c5a2ea40 h1:BtUFROTRzj9Y8jXjyUJ4No
 golang.org/x/text v0.3.1-0.20181030141323-6f44c5a2ea40/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=


### PR DESCRIPTION
- taskrunner: upgrade required go version to 1.17
- taskrunner: add .gitignore
- taskrunner .github: use go 1.17 in coverage step
- taskrunner .github: go-get goveralls after running tests
