### PR TITLE
runner: add task specific help command to --help

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -52,8 +52,21 @@ func newRuntime() *Runtime {
 	}
 
 	r.flags.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: taskrunner [task...]\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "[Usage]\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        taskrunner [task...]\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        taskrunner [task] --help\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        taskrunner [option]\n")
+		fmt.Fprintln(flag.CommandLine.Output())
+		fmt.Fprintf(flag.CommandLine.Output(), "[Options]\n")
 		r.flags.PrintDefaults()
+		fmt.Fprintln(flag.CommandLine.Output())
+		fmt.Fprintf(flag.CommandLine.Output(), "[Example Usage]\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        `taskrunner mytask`\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        `taskrunner mytask ---help`\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        `taskrunner mytask1 mytask2`\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        `taskrunner mytask --mode=dev`\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        `taskrunner --config ./customconfig.json mytask --mode=dev`\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        `taskrunner --list`\n")
 	}
 	r.flags.StringVar(&configFile, "config", "", "Configuration file to use")
 	r.flags.BoolVar(&nonInteractive, "non-interactive", false, "Non-interactive mode (only applies when running the default set of tasks)")


### PR DESCRIPTION
Since we have released flag support, we now support:
`taskrunner [task] --help` which gives rich details on the task like
description, supported flags.

looks like
```
[Usage]
        taskrunner [task...]
        taskrunner [task] --help
        taskrunner [option]

[Options]
  -config string
    	Configuration file to use
  -describe
    	Describe all tasks
  -ignore-cache
    	Ignore task invalidation cache
  -list
    	List all tasks except those marked "Hidden"
  -listAll
    	List all tasks including those marked as "Hidden"
  -non-interactive
    	Non-interactive mode (only applies when running the default set of tasks)
  -watch
    	Run in watch mode (only applies when passing custom tasks)

[Example Usage]
        `taskrunner mytask`
        `taskrunner mytask ---help`
        `taskrunner mytask1 mytask2`
        `taskrunner mytask --mode=dev`
        `taskrunner --config ./customconfig.json mytask --mode=dev`
        `taskrunner --list`
```
