### PR TITLE
runner: fail on any invalid tasks

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -127,7 +127,7 @@ func (r *Runtime) groupTaskAndFlagArgs(args []string) (map[string][]string, bool
 				currFlagsList = []string{}
 			} else {
 				foundInvalidTasks = true
-				logger.Printf("Unrecognized task: %s, ignoring it and following flags\n", arg)
+				logger.Printf("Unrecognized task: %s\n", arg)
 				// Note that in this case, currTaskName must be "" to ignore following flags.
 			}
 		}
@@ -204,19 +204,19 @@ func Run(options ...RunOption) {
 
 	taskAndFlagArgs := runtime.flags.Args() // command-line arguments that are not flags for taskrunner itself
 	taskFlagGroups, foundInvalidTasks := runtime.groupTaskAndFlagArgs(taskAndFlagArgs)
+	if foundInvalidTasks { // fail if any task was invalid
+		logger.Fatalln("Error: invalid target task(s) found")
+		return
+	}
+
 	var desiredTasks []string
 	for taskName := range taskFlagGroups {
 		desiredTasks = append(desiredTasks, taskName)
 	}
 	watchMode := watch
 	if len(desiredTasks) == 0 {
-		if foundInvalidTasks { // tasks were specified, but all invalid
-			logger.Fatalln("Error: invalid target task(s)")
-			return
-		} else { // no tasks were specified
-			desiredTasks = c.DesiredTasks
-			watchMode = !nonInteractive
-		}
+		desiredTasks = c.DesiredTasks
+		watchMode = !nonInteractive
 	}
 	logger.Println("Desired tasks:", strings.Join(desiredTasks, ", "))
 	logger.Printf("Watch mode: %t\n", watchMode)

--- a/runner_internal_test.go
+++ b/runner_internal_test.go
@@ -66,9 +66,9 @@ func TestRunnerRun_FatalScenarios(t *testing.T) {
 			expectedFatal: false,
 		},
 		{
-			description:   "Fatals when task is specified but unknown",
+			description:   "Fatals when an unknown task is specified",
 			tasks:         []*Task{mockTask},
-			cliArgs:       []string{"", "--config", testConfigFile, "unknown/task", "--someFlag"},
+			cliArgs:       []string{"", "--config", testConfigFile, "basic", "unknown/task", "--someFlag"},
 			expectedFatal: true,
 		},
 	}


### PR DESCRIPTION
Instead of partially succeeding on a mix of valid and invalid tasks,
fail when any task is invalid. The list of tasks passed in can be
thought of a single unit of intended outcome, and hence the new
behavior serves the user better - also is less ambiguous.
