### PR TITLE
GH Actions CI: determine Go version from go.mod

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17.x
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.17.x'
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This configures the use of `taskrunner`'s `go.mod` to dynamically determine the proper Go version to use in CI from a single source of truth, rather than redundantly hard-coding that value within the workflow YAML.