### PR TITLE
process: also handle SIGHUP in `onInterruptSignal`

### DIFF
--- a/process.go
+++ b/process.go
@@ -6,10 +6,11 @@ import (
 	"syscall"
 )
 
-// OnInterruptSignal invokes fn when SIGNINT/SIGTERM is received.
+// OnInterruptSignal invokes fn when an interrupt signal is received.
+// We loosely define the interrupt signal as SIGINT, SIGTERM, and SIGHUP.
 func onInterruptSignal(fn func()) {
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
 		<-signalChan
 		fn()


### PR DESCRIPTION
`onInterruptSignal` is a function that accepts a cleanup function and
runs it on SIGINT and SIGTERM. Update to also run cleanup on SIGHUP.
Major use case is to handle broken SSH connections.

Tested using VSCode remote terminal and manual SSH over iTerm.
