### PR TITLE
Update to actions/cache@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
actions/cache@v2 is deprecated, so we should update to the latest version.  Any actions using v2 will instantly fail, so this is necessary to get our actions CI working.