### PR TITLE
buildkitereporter: add owner to annotations

### DIFF
--- a/buildkitereporter/buildkitereporter.go
+++ b/buildkitereporter/buildkitereporter.go
@@ -181,11 +181,16 @@ func (r *reporter) write(tasks []*taskrunner.TaskHandler) (io.Reader, int) {
 	fmt.Fprintf(&buf, "<h5>%s taskrunner: %d tasks failed</h5>\n", os.Getenv("BUILDKITE_LABEL"), failureCount)
 
 	for _, task := range failedTasks {
+		ownerMsg := ""
+		if task.Owner != "" {
+			ownerMsg = fmt.Sprintf("task owner: %s\n", task.Owner)
+		}
 		fmt.Fprintf(&buf, "<details><summary><code>%s</code></summary>\n<pre>", task.Name)
 		for _, out := range r.stderrs[task] {
 			fmt.Fprintf(&buf, "<code>%s</code>\n", out)
 		}
 		fmt.Fprintln(&buf, "</pre></details>")
+		fmt.Fprint(&buf, ownerMsg)
 	}
 
 	return &buf, failureCount


### PR DESCRIPTION
Now that we have added optional owners to Taskrunner tasks, in the event a task fails in a Buildkite workflow, this will include the owner in the resulting annotation.

Example:
Above task has an owner, task below does not
<img width="1669" alt="Screenshot 2025-05-28 at 12 19 01 PM" src="https://github.com/user-attachments/assets/6ca2ac18-d862-4d80-a48d-a05602c36fe8" />

Update to put owner below summary:
![Uploading Screenshot 2025-05-28 at 2.03.51 PM.png…]()


