### PR TITLE
clireporter: add space after separator for IDE file link detection

### DIFF
--- a/clireporter/cli.go
+++ b/clireporter/cli.go
@@ -29,7 +29,7 @@ func FileAppendOption(r *taskrunner.Runtime) {
 	}
 
 	logger := newLogger(f)
-	logger.SetSeparator("|")
+	logger.SetSeparator("| ")
 
 	option(logger)(r)
 }
@@ -46,7 +46,7 @@ func FileByDateOption(r *taskrunner.Runtime) {
 	}
 
 	logger := newLogger(f)
-	logger.SetSeparator("|")
+	logger.SetSeparator("| ")
 
 	option(logger)(r)
 }


### PR DESCRIPTION
## Summary
- Add trailing space to the pipe separator in log output so IDEs can correctly parse filenames

## Problem
When taskrunner outputs logs with filenames (e.g., from `typecheck`), the pipe separator immediately precedes the filename with no space:

```
     typecheck |go/src/samsaradev.io/api/foo.go:123:45 error message
```

This causes VS Code (and other IDEs) integrated terminals to interpret the `|` as part of the filename when using cmd+click to open files, resulting in a "file not found" dialog.

## Solution
Add a trailing space to the separator: `"|"` → `"| "`

```
     typecheck | go/src/samsaradev.io/api/foo.go:123:45 error message
```

This allows IDEs to correctly detect and open the file path.

## Testing
- Build passes
- Verified the output format in `prefixedwriter.go` - the separator is used directly in the format string with no additional spacing

Fixes: https://samsara.slack.com/archives/C02KRH25X2E/p1736197501140599