### PR TITLE
goextensions: preserve caller sources; cache: don't fatal on transient git failures

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -54,11 +54,13 @@ func getCacheFilePath(dir string) string {
 }
 
 func (c *Cache) Start(ctx context.Context) error {
-	c.snapshotter = newSnapshotter(
-		func(ctx context.Context, command string, opts ...shell.RunOption) error {
-			return shell.Run(ctx, command, append(opts, c.opts...)...)
-		},
-	)
+	if c.snapshotter == nil {
+		c.snapshotter = newSnapshotter(
+			func(ctx context.Context, command string, opts ...shell.RunOption) error {
+				return shell.Run(ctx, command, append(opts, c.opts...)...)
+			},
+		)
+	}
 
 	s, err := c.snapshotter.Read(c.cacheFile)
 	// If we can't get a cache file, assume that everything is dirty and needs to be re-run.
@@ -73,7 +75,10 @@ func (c *Cache) Start(ctx context.Context) error {
 
 	files, err := c.snapshotter.Diff(ctx, s)
 	if err != nil {
-		return err
+		// Don't fatal on transient git failures; fall back to allDirty so the run makes forward progress.
+		log.Printf("Warning: cache diff failed (%v), treating all files as dirty", err)
+		c.allDirty = true
+		return nil
 	}
 	c.dirtyFiles = files
 
@@ -85,7 +90,12 @@ func (c *Cache) Finish(ctx context.Context) error {
 	if err := os.MkdirAll(CacheDir, os.ModePerm); err != nil {
 		return err
 	}
-	return c.snapshotter.Write(ctx, c.cacheFile)
+	if err := c.snapshotter.Write(ctx, c.cacheFile); err != nil {
+		// Don't fatal here either; the next run just won't benefit from caching.
+		log.Printf("Warning: cache write failed (%v), next run will not benefit from caching", err)
+		return nil
+	}
+	return nil
 }
 
 func (c *Cache) isFirstRun(task *taskrunner.Task) bool {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,41 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var errGitFailed = errors.New("git rev-parse HEAD failed: exit status 128; stderr: fatal: not a git repository")
+
+func failingSnapshotter() *snapshotter {
+	return &snapshotter{
+		CommitFunc: func(ctx context.Context) (string, error) {
+			return "", errGitFailed
+		},
+		UncommittedFilesFunc: func(ctx context.Context) ([]string, []string, error) {
+			return nil, nil, nil
+		},
+		HashFunc: func(s string) (string, error) { return s, nil },
+	}
+}
+
+func TestCache_StartGitFailureIsNonFatal(t *testing.T) {
+	c := New()
+	c.snapshotter = failingSnapshotter()
+
+	err := c.Start(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, c.allDirty, "expected allDirty=true when git fails")
+}
+
+func TestCache_FinishGitFailureIsNonFatal(t *testing.T) {
+	c := New()
+	c.snapshotter = failingSnapshotter()
+	c.cacheFile = t.TempDir() + "/cache"
+
+	err := c.Finish(context.Background())
+	assert.NoError(t, err)
+}

--- a/cache/git.go
+++ b/cache/git.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/taskrunner/shell"
 )
 
@@ -22,27 +23,27 @@ func splitStdout(buf bytes.Buffer) []string {
 }
 
 func (g gitClient) currentCommit(ctx context.Context) (commitHash string, err error) {
-	var buffer bytes.Buffer
-	if err := g.shellRun(ctx, "git rev-parse HEAD", shell.Stdout(&buffer)); err != nil {
-		return "", err
+	var buffer, stderr bytes.Buffer
+	if err := g.shellRun(ctx, "git rev-parse HEAD", shell.Stdout(&buffer), shell.Stderr(&stderr)); err != nil {
+		return "", oops.Wrapf(err, "git rev-parse HEAD; stderr: %s", stderr.String())
 	}
 
 	return stripStdout(buffer), nil
 }
 
 func (g gitClient) diff(ctx context.Context, commitHash string) (modifiedFiles []string, error error) {
-	var buffer bytes.Buffer
-	if err := g.shellRun(ctx, fmt.Sprintf("git diff --name-only %s", commitHash), shell.Stdout(&buffer)); err != nil {
-		return nil, err
+	var buffer, stderr bytes.Buffer
+	if err := g.shellRun(ctx, fmt.Sprintf("git diff --name-only %s", commitHash), shell.Stdout(&buffer), shell.Stderr(&stderr)); err != nil {
+		return nil, oops.Wrapf(err, "git diff --name-only %s; stderr: %s", commitHash, stderr.String())
 	}
 
 	return splitStdout(buffer), nil
 }
 
 func (g gitClient) uncomittedFiles(ctx context.Context) (newFiles []string, modifiedFiles []string, err error) {
-	var buffer bytes.Buffer
-	if err := g.shellRun(ctx, "git status --porcelain", shell.Stdout(&buffer)); err != nil {
-		return nil, nil, err
+	var buffer, stderr bytes.Buffer
+	if err := g.shellRun(ctx, "git status --porcelain", shell.Stdout(&buffer), shell.Stderr(&stderr)); err != nil {
+		return nil, nil, oops.Wrapf(err, "git status --porcelain; stderr: %s", stderr.String())
 	}
 
 	for _, statusLine := range splitStdout(buffer) {

--- a/goextensions/builder.go
+++ b/goextensions/builder.go
@@ -256,7 +256,8 @@ func (builder *GoBuilder) WrapWithGoBuild(pkg string) taskrunner.TaskOption {
 			for _, dependency := range dependencies {
 				sources = append(sources, "**/"+dependency+"/*.go")
 			}
-			newTask.Sources = append(task.Sources, sources...)
+			// Append onto newTask.Sources, not task.Sources, so caller-added sources survive.
+			newTask.Sources = append(newTask.Sources, sources...)
 
 			return shellRun, nil
 		}

--- a/goextensions/builder_test.go
+++ b/goextensions/builder_test.go
@@ -45,3 +45,34 @@ func TestWrapWithGoBuild_Sources(t *testing.T) {
 		File: "github.com/samsarahq/taskrunner/goextensions/foo/bar/bar.go",
 	}))
 }
+
+// TestWrapWithGoBuild_PreservesCallerSources guards against the regression where
+// running the wrapped task would clobber sources the caller appended to
+// newTask.Sources after the wrapper returned. The previous augmentTask
+// implementation did
+//
+//	newTask.Sources = append(task.Sources, deps...)
+//
+// where task is the *input* task -- so any source appended post-wrap (e.g.
+// samsaradev.io/helpers.go's catch-all "go/src/samsaradev.io/**/*.go") was
+// silently dropped on first execution.
+func TestWrapWithGoBuild_PreservesCallerSources(t *testing.T) {
+	builder := goextensions.NewGoBuilder()
+	wrapper := builder.WrapWithGoBuild("github.com/samsarahq/taskrunner/goextensions/foo")
+
+	task := wrapper(&taskrunner.Task{
+		Run: func(_ context.Context, _ shell.ShellRun) error {
+			return nil
+		},
+	})
+
+	// Simulate a caller appending an extra source after the wrapper returns.
+	const callerSource = "custom/sentinel/*.go"
+	task.Sources = append(task.Sources, callerSource)
+	assert.Contains(t, task.Sources, callerSource)
+
+	require.NoError(t, task.Run(context.Background(), shell.Run))
+
+	assert.Contains(t, task.Sources, callerSource,
+		"caller-appended source must survive a task execution")
+}


### PR DESCRIPTION
## Summary

Two independent bug fixes in different packages — no shared root cause, but both surfaced during the same investigation. The downstream team bumped its taskrunner pin past [`eb5f1b5`](https://github.com/samsarahq/taskrunner/commit/eb5f1b5), hit issues, and reverted to a pre-`eb5f1b5` pin. Digging into what those issues were turned up the two bugs this PR fixes. The hope is that with both applied, we can re-bump the downstream pin forward — that hasn't been confirmed yet, validation will come from the downstream bump PR.

1. **`goextensions: preserve caller-appended sources in WrapWithGoBuild`** (commit `2d036ab`) — fixes a one-word bug introduced in `eb5f1b5` where `augmentTask` clobbered any source the caller appended to the wrapper's `newTask.Sources`.
2. **`cache: don't fatal on transient git failures`** (commit `1397f49`) — demotes a process-killing error from CI git flakes to a warning + degraded-but-correct fallback.

---

## Fix 1 — `goextensions: preserve caller-appended sources in WrapWithGoBuild`

[`eb5f1b5`](https://github.com/samsarahq/taskrunner/commit/eb5f1b5) added per-package source globs to `WrapWithGoBuild`. Inside its `augmentTask` closure:

```go
newTask.Sources = append(task.Sources, sources...)
```

That uses `task.Sources` (the *input* task) rather than `newTask.Sources` (the wrapper's own task). On the first task execution, this **deterministically clobbers** any source the caller appended to `newTask.Sources` after the wrapper returned.

Downstream impact: consumers that wrap upstream `WrapWithGoBuild` and append a catch-all glob to `newTask.Sources` after the wrap — for example samsaradev.io's `helpers.go` adding `"go/src/samsaradev.io/**/*.go"` — had that glob silently dropped on first task execution. From then on the watcher only matched the package's per-task discovered dep set; file edits anywhere outside that set stopped invalidating the task.

This is one mechanism that contributes to the "sporadic hot-reload" behavior reported after upgrading the taskrunner pin past `eb5f1b5`. There are at least two other changes in `eb5f1b5` that could also contribute (the `ShouldInvalidate` matcher tightening from `strings.Contains` to `strings.HasSuffix(filepath.Dir, dep)`, and the goroutine race on the `Sources` slice header — `augmentTask` mutates it while the watcher reads it). Those are out of scope for this PR. Final validation that this fix is sufficient for our downstream consumer comes from the bump-pin run there; if not, a follow-up addresses whichever of the other factors is implicated.

### Fix

One-word change: append onto `newTask.Sources` rather than `task.Sources`. Prior caller appends are preserved.

### Test

`TestWrapWithGoBuild_PreservesCallerSources` in `goextensions/builder_test.go` pins the contract: a source appended to `task.Sources` after the wrapper returns must survive a task execution. Restoring `eb5f1b5`'s `goextensions/builder.go` on top of this test reproduces the bug exactly (test FAILS); restoring this PR's `builder.go` flips it to PASS.

---

## Fix 2 — `cache: don't fatal on transient git failures`

`cache.Start` and `cache.Finish` shell out to `git rev-parse HEAD`, `git diff --name-only`, and `git status --porcelain` via the snapshotter. In CI these intermittently fail with exit 128 — cwd outside the repo, dubious-ownership warnings, index lock contention, etc. The error propagated up through the `OnStart`/`OnStop` hooks and killed the entire taskrunner process with `run error: exit status 128`. Downstream consumers report this as a meaningful share of flaky CI failures (the original bug was filed under a downstream tracker as CICD-4356).

### Fix

- `Start`: a failed `Diff` is logged as a warning and treated as `allDirty=true`, so the run still makes forward progress (just rebuilds everything instead of using cached state).
- `Finish`: a failed snapshot `Write` is logged as a warning and swallowed; the next run just won't benefit from caching.
- `cache/git.go`: capture stderr in all three git invocations and use `oops.Wrapf` (matching the rest of the repo's error-wrapping convention), so the warnings include the actual underlying git error rather than just "exit status 128".
- `Start`: skip snapshotter construction when `c.snapshotter` is already set — lets tests inject a fake.

### Test

New `cache/cache_test.go` exercises both Start and Finish with a snapshotter whose CommitFunc returns an error simulating exit-128. Both tests assert no error returned and (for Start) that `allDirty` is set.

End-to-end repro the team's been using:

```bash
EXPERIMENTAL_TASKRUNNER_NEWTUI=0 GIT_DIR=/dev/null taskrunner verify/engines
# Before this PR: dies with `run error: exit status 128`
# After this PR:  logs `Warning: cache diff failed (...)` and runs to completion
```

---

## Test plan + verification done

Linux devbox, Go 1.24.2 (matches `go.mod`).

### Unit + suite

- [x] `go vet ./...` clean
- [x] `go test -v ./... -coverprofile=coverage.out -covermode=atomic -bench=./...` passes — same command CI runs in `.github/workflows/main.yml`
- [x] `goextensions` coverage is 82.9% on this branch
- [x] `cache` coverage is 47.3% on this branch

### Cache fix end-to-end against real taskrunner

Original repro: `EXPERIMENTAL_TASKRUNNER_NEWTUI=0 GIT_DIR=/dev/null taskrunner verify/engines` against downstream consumer, with the upstream pin pointed at the local clone (toggled between master and this branch).

**On master (the broken upstream):**

```
2026/.../.. Watch mode: false
2026/.../.. run error:
exit status 128

github.com/samsarahq/taskrunner.Run.func4: running executor
        /home/ubuntu/co/taskrunner/runner.go:274
```

Exit 1, crash before `verify/engines` ever runs.

**On this branch:**

```
2026/.../.. Watch mode: false
2026/.../.. Warning: cache diff failed (git rev-parse HEAD; stderr: fatal: not a git repository: '/dev/null': exit status 128), treating all files as dirty
verify/engines > Started
verify/engines > Completed (0.27s)
2026/.../.. Warning: cache write failed (...), next run will not benefit from caching
```

Exit 0, `verify/engines` runs to completion. Same command, same `GIT_DIR`, only the upstream pin differs.

### Hot-reload smoke test against real taskrunner

`taskrunner --watch <service-name>` against downstream consumer on this branch with the catch-all glob temporarily commented out of `helpers.go` (mirrors a prior intermediate state). Once the service was up, touchinga known dep produced:

```
$ grep -c "Invalidating <service-name>" /tmp/repro-fixed.log
3
```

Hot-reload fires, build re-runs, daemon restarts cleanly. Comment-only edits to the same file also fire the rebuild as expected.

### Caller-source-clobber A/B (the bug being fixed)

The unit-level proof:

```
# fix branch builder.go
$ go test ./goextensions/... -run TestWrapWithGoBuild_PreservesCallerSources -v
PASS

# eb5f1b5's builder.go (the broken upstream)
$ git show eb5f1b5:goextensions/builder.go > goextensions/builder.go
$ go test ./goextensions/... -run TestWrapWithGoBuild_PreservesCallerSources -v
FAIL  task.Sources no longer contains "custom/sentinel/*.go" after task.Run
```

### Downstream verification *(not yet done in this PR)*

- [ ] Bump pin in downstream repo to a pseudoversion of this PR's commit and run Buildkite — will be done in a follow-up PR there

---

## FAQ for likely review questions

**Q: Why `newTask.Sources` instead of removing the Sources mutation entirely?**
A: The intent of `eb5f1b5` was selective per-task source globs derived from the dep tree, replacing downstream catch-all globs. That intent is sound and worth preserving — the fix just makes the line behave the way the surrounding code reads.

**Q: Does this fix the full sporadic-hot-reload symptom downstream consumers reported?**
A: It fixes one *deterministic* mechanism (the source clobber). There are at least two other plausible contributors in `eb5f1b5` — a stricter `ShouldInvalidate` matcher and a goroutine race on `Sources` slice-header. Whether either of those is also user-visible in a given downstream depends on the downstream's setup. If the catch-all glob is restored in the consumer's wrapper, this fix preserves it through task execution, which is the main thing. If the bump goes green downstream, that's confirmation; if not, follow-ups.

**Q: Will this break consumers who don't append sources after `WrapWithGoBuild`?**
A: No. The change is `append(task.Sources, ...)` → `append(newTask.Sources, ...)`. `newTask` is initialized as `*task` at the top of the wrapper, so for any consumer who never touched `newTask.Sources`, the result is identical. Only consumers who *did* append to `newTask.Sources` see different behavior — and that behavior is "their sources don't get clobbered", which is the bug fix.

**Q: Why `oops.Wrapf` instead of `fmt.Errorf` in `cache/git.go`?**
A: Matches the rest of the repo (`watcher/watcher.go`, `shell/shell.go`). `oops` attaches the call-site frame, which makes root-causing CI failures easier when these errors land in a log.

**Q: Why two unrelated fixes in one PR?**
A: Both came up during the same downstream investigation, and the goal is to test whether re-bumping the downstream pin past `eb5f1b5` is safe with both applied. Bundled here for that reason. Happy to split into two PRs if you prefer — they have no shared root cause and don't depend on each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
