### PR TITLE
goextensions: stop appending per-dep globs to Task.Sources

### DIFF
--- a/goextensions/builder.go
+++ b/goextensions/builder.go
@@ -249,14 +249,10 @@ func (builder *GoBuilder) WrapWithGoBuild(pkg string) taskrunner.TaskOption {
 			if err != nil {
 				return nil, err
 			}
+			// Filtering happens via shouldInvalidate; do NOT push deps into
+			// newTask.Sources — the watcher's single-threaded zglob.Match loop
+			// becomes O(tasks × deps) per event and stalls invalidations.
 			buildBinder.pkgDependencies = dependencies
-
-			sources := make([]string, 0, len(dependencies))
-			// Watch all Go files in each dependent package.
-			for _, dependency := range dependencies {
-				sources = append(sources, "**/"+dependency+"/*.go")
-			}
-			newTask.Sources = append(task.Sources, sources...)
 
 			return shellRun, nil
 		}

--- a/goextensions/builder_test.go
+++ b/goextensions/builder_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWrapWithGoBuild_Sources(t *testing.T) {
+func TestWrapWithGoBuild_ShouldInvalidate(t *testing.T) {
 	builder := goextensions.NewGoBuilder()
 	wrapper := builder.WrapWithGoBuild("github.com/samsarahq/taskrunner/goextensions/foo")
 
@@ -22,7 +22,7 @@ func TestWrapWithGoBuild_Sources(t *testing.T) {
 	})
 	assert.NotNil(t, task)
 
-	// No sources until we run the task. Invalidate on any Go file change.
+	// Before the task has run, dependencies are unknown — invalidate on any Go file change.
 	assert.Empty(t, task.Sources)
 	assert.True(t, task.ShouldInvalidate(taskrunner.FileChange{
 		File: "github.com/samsarahq/taskrunner/goextensions/unrelated/baz.go",
@@ -30,11 +30,9 @@ func TestWrapWithGoBuild_Sources(t *testing.T) {
 
 	err := task.Run(context.Background(), shell.Run)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, task.Sources, []string{
-		"**/github.com/samsarahq/taskrunner/goextensions/foo/*.go",
-		"**/github.com/samsarahq/taskrunner/goextensions/foo/bar/*.go",
-	})
-	// Only invalidate on relevant Go file changes.
+
+	// Sources is intentionally left empty; non-dep filtering is done via ShouldInvalidate.
+	assert.Empty(t, task.Sources)
 	assert.False(t, task.ShouldInvalidate(taskrunner.FileChange{
 		File: "github.com/samsarahq/taskrunner/goextensions/unrelated/baz.go",
 	}))


### PR DESCRIPTION
## Summary

- `WrapWithGoBuild` (introduced in eb5f1b5) appended `**/<dep>/*.go` patterns to each wrapped task's `Task.Sources` for every transitive Go dependency. Combined with the watcher's single-threaded event loop running `zglob.Match` (which compiles a regex per call, no caching) for every Source on every file event, matching became O(tasks × deps) per event. In samsaradev.io this stalled invalidations by 10s–2min once all tasks were running.
- Dependency filtering still happens cheaply in `shouldInvalidate` (filepath.Dir + strings.HasSuffix over a small dep list), so the Sources arm was redundant in addition to being expensive.
- This PR drops only the Sources mutation. The saved `pkgDependencies` and the improved `shouldInvalidate` matcher from eb5f1b5 are preserved.

## Why this is safe

- Pre-eb5f1b5, `WrapWithGoBuild` did not touch `newTask.Sources` at all — this PR restores that exact behavior for Sources while keeping eb5f1b5's improved matcher.
- Tasks that supply their own Sources (e.g. samsaradev.io's catch-all `go/src/samsaradev.io/**/*.go`) are unaffected: `IsTaskSource` still passes `.go` events through, and `shouldInvalidate` does the per-dep filtering downstream.

## Edge case noted

A caller who relies solely on `WrapWithGoBuild` to populate Sources (no own glob, no downstream catch-all) will not receive file-event invalidations — same as pre-eb5f1b5. The `WrapWithGoBuild` docstring still implies auto-setup; if we want to honor that without re-introducing the perf cliff, a follow-up could fall back to a single coarse `**/*.go` only when `len(newTask.Sources) == 0`. Not included here to keep the fix surgical.

## Test plan

- [ ] `go test ./goextensions/...` (renamed `TestWrapWithGoBuild_Sources` → `TestWrapWithGoBuild_ShouldInvalidate`; asserts Sources stays empty after task run).
- [ ] Manual repro in samsaradev.io: edit `userpreferencesservice/main.go` after taskrunner is fully started; the `userpreferencesservice/build` task invalidates within seconds (previously 10s–2min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)