### PR TITLE
cache: don't fatal on transient git failures, tag hook errors with index

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -54,11 +54,13 @@ func getCacheFilePath(dir string) string {
 }
 
 func (c *Cache) Start(ctx context.Context) error {
-	c.snapshotter = newSnapshotter(
-		func(ctx context.Context, command string, opts ...shell.RunOption) error {
-			return shell.Run(ctx, command, append(opts, c.opts...)...)
-		},
-	)
+	if c.snapshotter == nil {
+		c.snapshotter = newSnapshotter(
+			func(ctx context.Context, command string, opts ...shell.RunOption) error {
+				return shell.Run(ctx, command, append(opts, c.opts...)...)
+			},
+		)
+	}
 
 	s, err := c.snapshotter.Read(c.cacheFile)
 	// If we can't get a cache file, assume that everything is dirty and needs to be re-run.
@@ -73,7 +75,10 @@ func (c *Cache) Start(ctx context.Context) error {
 
 	files, err := c.snapshotter.Diff(ctx, s)
 	if err != nil {
-		return err
+		// Don't fatal on transient git failures; fall back to allDirty so the run makes forward progress.
+		log.Printf("Warning: cache diff failed (%v), treating all files as dirty", err)
+		c.allDirty = true
+		return nil
 	}
 	c.dirtyFiles = files
 
@@ -85,7 +90,12 @@ func (c *Cache) Finish(ctx context.Context) error {
 	if err := os.MkdirAll(CacheDir, os.ModePerm); err != nil {
 		return err
 	}
-	return c.snapshotter.Write(ctx, c.cacheFile)
+	if err := c.snapshotter.Write(ctx, c.cacheFile); err != nil {
+		// Don't fatal here either; the next run just won't benefit from caching.
+		log.Printf("Warning: cache write failed (%v), next run will not benefit from caching", err)
+		return nil
+	}
+	return nil
 }
 
 func (c *Cache) isFirstRun(task *taskrunner.Task) bool {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,41 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var errGitFailed = errors.New("git rev-parse HEAD failed: exit status 128; stderr: fatal: not a git repository")
+
+func failingSnapshotter() *snapshotter {
+	return &snapshotter{
+		CommitFunc: func(ctx context.Context) (string, error) {
+			return "", errGitFailed
+		},
+		UncommittedFilesFunc: func(ctx context.Context) ([]string, []string, error) {
+			return nil, nil, nil
+		},
+		HashFunc: func(s string) (string, error) { return s, nil },
+	}
+}
+
+func TestCache_StartGitFailureIsNonFatal(t *testing.T) {
+	c := New()
+	c.snapshotter = failingSnapshotter()
+
+	err := c.Start(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, c.allDirty, "expected allDirty=true when git fails")
+}
+
+func TestCache_FinishGitFailureIsNonFatal(t *testing.T) {
+	c := New()
+	c.snapshotter = failingSnapshotter()
+	c.cacheFile = t.TempDir() + "/cache"
+
+	err := c.Finish(context.Background())
+	assert.NoError(t, err)
+}

--- a/cache/git.go
+++ b/cache/git.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/taskrunner/shell"
 )
 
@@ -22,27 +23,27 @@ func splitStdout(buf bytes.Buffer) []string {
 }
 
 func (g gitClient) currentCommit(ctx context.Context) (commitHash string, err error) {
-	var buffer bytes.Buffer
-	if err := g.shellRun(ctx, "git rev-parse HEAD", shell.Stdout(&buffer)); err != nil {
-		return "", err
+	var buffer, stderr bytes.Buffer
+	if err := g.shellRun(ctx, "git rev-parse HEAD", shell.Stdout(&buffer), shell.Stderr(&stderr)); err != nil {
+		return "", oops.Wrapf(err, "git rev-parse HEAD; stderr: %s", stderr.String())
 	}
 
 	return stripStdout(buffer), nil
 }
 
 func (g gitClient) diff(ctx context.Context, commitHash string) (modifiedFiles []string, error error) {
-	var buffer bytes.Buffer
-	if err := g.shellRun(ctx, fmt.Sprintf("git diff --name-only %s", commitHash), shell.Stdout(&buffer)); err != nil {
-		return nil, err
+	var buffer, stderr bytes.Buffer
+	if err := g.shellRun(ctx, fmt.Sprintf("git diff --name-only %s", commitHash), shell.Stdout(&buffer), shell.Stderr(&stderr)); err != nil {
+		return nil, oops.Wrapf(err, "git diff --name-only %s; stderr: %s", commitHash, stderr.String())
 	}
 
 	return splitStdout(buffer), nil
 }
 
 func (g gitClient) uncomittedFiles(ctx context.Context) (newFiles []string, modifiedFiles []string, err error) {
-	var buffer bytes.Buffer
-	if err := g.shellRun(ctx, "git status --porcelain", shell.Stdout(&buffer)); err != nil {
-		return nil, nil, err
+	var buffer, stderr bytes.Buffer
+	if err := g.shellRun(ctx, "git status --porcelain", shell.Stdout(&buffer), shell.Stderr(&stderr)); err != nil {
+		return nil, nil, oops.Wrapf(err, "git status --porcelain; stderr: %s", stderr.String())
 	}
 
 	for _, statusLine := range splitStdout(buffer) {

--- a/executor.go
+++ b/executor.go
@@ -272,9 +272,9 @@ func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime
 
 	var errors error
 	// Run all onStartHooks before starting, after the DAG has been created.
-	for _, hook := range runtime.onStartHooks {
+	for i, hook := range runtime.onStartHooks {
 		if err := hook(ctx, e); err != nil {
-			errors = multierr.Append(errors, err)
+			errors = multierr.Append(errors, oops.Wrapf(err, "OnStart hook %d failed", i))
 		}
 	}
 	if errors != nil {
@@ -287,9 +287,9 @@ func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime
 	errors = multierr.Append(errors, e.wg.Wait())
 
 	// Run all onStopHooks after stopping.
-	for _, hook := range runtime.onStopHooks {
+	for i, hook := range runtime.onStopHooks {
 		if err := hook(ctx, e); err != nil {
-			errors = multierr.Append(errors, err)
+			errors = multierr.Append(errors, oops.Wrapf(err, "OnStop hook %d failed", i))
 		}
 	}
 


### PR DESCRIPTION
## Summary
Whenever we get 128 exit logs, we get barely any information:
[buildkite link](https://buildkite.com/samsara/backend-test/builds/1706000#019dddba-7b69-42ca-a34e-3d7999732ef1)
```
2026-04-30 02:34:26 PDT | Installing taskrunner
-- | --
2026-04-30 02:34:29 PDT | Running taskrunner go/lint/samsaragovet/enforced
2026-04-30 02:34:30 PDT | 2026/04/30 09:34:30 Using config at /code/workspace.taskrunner.json
2026-04-30 02:34:30 PDT | 2026/04/30 09:34:30 Desired tasks: go/lint/samsaragovet/enforced
2026-04-30 02:34:30 PDT | 2026/04/30 09:34:30 Watch mode: false
2026-04-30 02:34:31 PDT | 2026/04/30 09:34:31 run error:
2026-04-30 02:34:31 PDT | exit status 128
2026-04-30 02:34:31 PDT |  
2026-04-30 02:34:31 PDT | github.com/samsarahq/taskrunner.Run.func4: running executor
2026-04-30 02:34:31 PDT | samsaradev.io/vendor/github.com/samsarahq/taskrunner/runner.go:270
2026-04-30 02:34:31 PDT | golang.org/x/sync/errgroup.(*Group).Go.func1
2026-04-30 02:34:31 PDT | samsaradev.io/vendor/golang.org/x/sync/errgroup/errgroup.go:93
```

There is a chance that this is related to git errors that are failing inside of the cached commands layer. If these commands fail, we don't need to necessarily hard fail, we'll just end up calling git directly.

`cache.Start` and `cache.Finish` shell out to `git rev-parse HEAD`, `git diff --name-only`, and `git status --porcelain`. In CI these intermittently fail with exit 128 (cwd outside the repo, dubious-ownership, index lock contention) and kill the taskrunner process with `run error: exit status 128`. Tracked downstream as CICD-4356.

Investigated 7 reported flakes — confirmed in samsara/backend-test #1706000 (job `019dddba-7b69`) and #1692229 (job `019dc106-0183`): both die ~1s after `Watch mode: false` with no task body output and a bare `exit status 128`, consistent with cache-snapshot OnStart hook errors that aren't currently wrapped or demoted. The remaining 5 flakes I was given turned out to be unrelated.

## Fix

- `Start`: a failed `Diff` is logged and treated as `allDirty=true`, so the run rebuilds everything.
- `Finish`: a failed snapshot `Write` is logged and swallowed; the next run won't benefit from caching.
- `cache/git.go`: capture stderr in the three git invocations and wrap with `oops.Wrapf` (matches the rest of the repo) so warnings include the underlying git error.
- `executor.go`: tag OnStart/OnStop hook errors with the hook index via `oops.Wrapf`, so a future hook failure surfaces as `OnStart hook 0 failed: …` instead of a bare error. This is the diagnostic gap that made the original `exit status 128` so opaque.

## Test plan

- [x] `go vet ./...` clean, `go test ./...` passes (cache coverage 47.3%)
- [x] New `cache/cache_test.go` covers Start and Finish with a snapshotter that errors with exit-128
- [ ] Downstream pin bump — follow-up PR there